### PR TITLE
Replace authorize() using cms-sdk

### DIFF
--- a/src/MiniRouter.php
+++ b/src/MiniRouter.php
@@ -1,7 +1,7 @@
 <?php
 namespace Ridibooks\Cms;
 
-use Ridibooks\Cms\Service\AdminAuthService;
+use Ridibooks\Cms\Auth\AdminAuthService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -159,39 +159,6 @@ class AdminAuthService
         return self::checkAuth($hash, $check_url, $auth_list);
     }
 
-    public static function authorize(Request $request) : ?Response
-    {
-        $user_id = LoginService::GetAdminID();
-        $request_uri = $request->getRequestUri();
-
-        if (!self::isValidLogin() || !self::isValidUser($user_id)) {
-            $login_url = '/login';
-            if (!empty($request_uri) && $request_uri != '/login') {
-                $login_url .= '?return_url=' . urlencode($request_uri);
-            }
-
-            return RedirectResponse::create($login_url);
-        }
-
-        $user_auth = self::readUserAuth($user_id);
-
-        try {
-            if (!self::checkAuth($hash, $request_uri, $user_auth)
-                && !$_ENV['DEBUG']) {
-                throw new \Exception("해당 권한이 없습니다.");
-            }
-        } catch (\Exception $e) {
-            // 이상하지만 기존과 호환성 맞추기 위해
-            if ($request->isXmlHttpRequest()) {
-                return new Response($e->getMessage());
-            } else { //일반 페이지
-                return new Response(UrlHelper::printAlertHistoryBack($e->getMessage()));
-            }
-        }
-
-        return null;
-    }
-
     // 해당 URL의 Hash 권한 Array를 반환한다.
     public static function getCurrentHashArray(string $check_url = null, string $admin_id = null) : array
     {


### PR DESCRIPTION
현재 authorize함수가 cms와 cms-sdk에 각각 구현되어 있는데 cms도 cms-sdk버전을 써버리면 어떨까 싶어서 수정해봤습니다. RPC호출이 있겠지만 localhost에서 처리하게하면 문제는 없을거 같아서요.
  