### PR TITLE
Fix menu duplication

### DIFF
--- a/src/Service/AdminUserService.php
+++ b/src/Service/AdminUserService.php
@@ -190,11 +190,11 @@ class AdminUserService implements AdminUserServiceIf
     {
         $ids = [];
         $unique = [];
-        foreach ($menus as $key => $value)
+        foreach ($menus as $menu)
         {
-            $id = $value->menu_id;
+            $id = $menu->menu_id;
             if (!isset($ids[$id])) {
-                $unique[$id] = $value;
+                $unique[$id] = $menu;
                 $ids[$id] = true;
             }
         }

--- a/src/Service/AdminUserService.php
+++ b/src/Service/AdminUserService.php
@@ -155,6 +155,7 @@ class AdminUserService implements AdminUserServiceIf
             where tb_admin2_user_menu.user_id = :user', ['user' => $user]);
 
         $menus = array_merge($user_tag_menus, $user_menus);
+        $menus = self::uniquifyMenus($menus);
 
         return array_map(function ($menu) use ($column) {
             return isset($column) ? $menu->{$column} : (array) $menu;
@@ -183,5 +184,20 @@ class AdminUserService implements AdminUserServiceIf
         return array_map(function ($ajax) use ($column) {
             return isset($column) ? $ajax->{$column} : (array) $ajax;
         }, $ajax_list);
+    }
+
+    public function uniquifyMenus(array $menus)
+    {
+        $ids = [];
+        $unique = [];
+        foreach ($menus as $key => $value)
+        {
+            $id = $value->menu_id;
+            if (!isset($ids[$id])) {
+                $unique[$id] = $value;
+                $ids[$id] = true;
+            }
+        }
+        return $unique;
     }
 }


### PR DESCRIPTION
하나의 메뉴가 직접추가되었거나, 태그를 통해 간접적으로 유저에게 부여되서 메뉴가 중복으로 나타나는 버그가 있습니다.

기존 1.x에는 db에서 menu id의 리스트만 가져와서 array_unique로 간단히 처리하지만 지금은 array의 array구조라서 다소 복잡하게 처리되었습니다. 좀 더 간단한 방법을 제안해주셔도 좋을것 같습니다.