### PR TITLE
Remove null hashes from getHashesFromMenus

### DIFF
--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -173,7 +173,7 @@ class AdminAuthService
             return self::parseUrlAuth($url)['hash'];
         }, $auth_urls);
 
-        return $hash_array;
+        return array_filter($hash_array);
     }
 
     public function hideEmptyRootMenus(array $menus): array


### PR DESCRIPTION
getHashesFromMenus에서 null이 포함될 수 있는데 (menu는 있으나 hash가 없는 경우 array_map결과로 null이 추출되어 들어감) 그런 경우 getHashesFromMenus결과를 Thrift로 내보내면서 예외가 발생합니다.  

array_filter를 적용해서 문제를 수정했습니다.