### PR TITLE
Add `redirect` parameter at /login

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -21,7 +21,8 @@ class LoginController implements ControllerProviderInterface
         $controller_collection = $app['controllers_factory'];
 
         // login page
-        $controller_collection->get('/login', [$this, 'login']);
+        $controller_collection->get('/login', [$this, 'getLoginPage']);
+        $controller_collection->get('/login-authorize', [$this, 'loginAuthorize']);
 
         // login process
         $controller_collection->get('/login-azure', [$this, 'azureLogin']);
@@ -34,7 +35,31 @@ class LoginController implements ControllerProviderInterface
         return $controller_collection;
     }
 
-    public function login(Request $request, CmsApplication $app)
+    public function getLoginPage(Request $request, CmsApplication $app)
+    {
+        $end_point = $this->buildAuthorizeEndpoint($request, $app);
+
+        $response = Response::create();
+        $return_url = $request->get('return_url', '/welcome');
+        $response->headers->setCookie(new Cookie('return_url', $return_url));
+
+        return $app->render('login.twig', [
+            'azure_login' => $end_point
+        ], $response);
+    }
+
+    public function loginAuthorize(Request $request, Application $app)
+    {
+        $end_point = $this->buildAuthorizeEndpoint($request, $app);
+
+        $response = RedirectResponse::create($end_point);
+        $return_url = $request->get('return_url', '/welcome');
+        $response->headers->setCookie(new Cookie('return_url', $return_url));
+
+        return $response;
+    }
+
+    private function buildAuthorizeEndpoint(Request $request, Application $app)
     {
         if (!empty($app['test_id'])) {
             $end_point = '/login-azure?code=test';
@@ -42,19 +67,7 @@ class LoginController implements ControllerProviderInterface
             $azure_config = $app['azure'];
             $end_point = AzureOAuth2Service::getAuthorizeEndPoint($azure_config);
         }
-        $return_url = $request->get('return_url', '/welcome');
-        $redirect = $request->get('redirect');
-
-        $response = $redirect ? RedirectResponse::create($end_point) : Response::create();
-        $response->headers->setCookie(new Cookie('return_url', $return_url));
-        
-        if ($redirect) {
-            return $response;
-        } else {
-            return $app->render('login.twig', [
-                'azure_login' => $end_point
-            ], $response);
-        }
+        return $end_point;
     }
 
     public function azureLogin(Request $request, Application $app)


### PR DESCRIPTION
/login페이지에 `redirect` 파라메터를 받으면 페이지를 보여주지 않고 바로 azure authorize 엔드포인트를 호출하도록 기능을 추가하였습니다.

이는 추후 리뷰할 cms-sdk PR에서 만료된 로그인 토큰의 자동 갱신을 위해 cms의 /login 엔드포인트를 사용하기 위함입니다.

https://app.asana.com/0/235684600038401/596133256149552

