### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
   # push (dev)
   - stage: push
     if: type = push AND branch IN (1.x, 2.x)
+    services:
+      - docker
     env:
       - DOCKER_TAG=${TRAVIS_BRANCH}
     script:
@@ -38,6 +40,8 @@ jobs:
   # push (prod)
   - stage: push
     if: tag =~ ^v\d+\.\d+(\.\d+)?$ # ex) v1.0.0 or v2.0.0
+    services:
+      - docker
     env:
       - DOCKER_TAG=${TRAVIS_TAG}
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
 
   # deploy 2.x (dev)
   - stage: deploy
-    if: type = push
+    if: type = push AND branch IN (1.x, 2.x)
     env:
       - CI_TRIGGER_ENV=dev
       - CI_TRIGGER_TARGET=cms-v2-restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,8 @@ cache:
 
 stages:
 - name: test
-
 - name: push
-  if: type = push
-
 - name: deploy
-  if: type = push
 
 jobs:
   include:
@@ -31,33 +27,48 @@ jobs:
       - bin/setup.sh
       - bin/test.sh
 
+  # push (dev)
   - stage: push
-    if: branch IN (1.x, 2.x)
-    services:
-      - docker
+    if: type = push AND branch IN (1.x, 2.x)
+    env:
+      - DOCKER_TAG=${TRAVIS_BRANCH}
     script:
       - bin/docker_push.sh
 
-  - stage: deploy
-    name: deploy-dev-v2
-    if: branch = 2.x
+  # push (prod)
+  - stage: push
+    if: tag =~ ^v\d+\.\d+(\.\d+)?$ # ex) v1.0.0 or v2.0.0
     env:
-      - CI_TRIGGER_ENV=dev CI_TRIGGER_TARGET=cms-v2-restart
+      - DOCKER_TAG=${TRAVIS_TAG}
+    script:
+      - bin/docker_push.sh
+
+  # deploy 2.x (dev)
+  - stage: deploy
+    if: type = push
+    env:
+      - CI_TRIGGER_ENV=dev
+      - CI_TRIGGER_TARGET=cms-v2-restart
+      - CI_TRIGGER_TAG=${TRAVIS_BRANCH}
     script:
       - bin/deploy.sh
 
+  # deploy 1.x (prod)
   - stage: deploy
-    name: deploy-prod-v1
-    if: branch = 1.x AND tag =~ ^1\.\d+(\.\d+)?$ # ex) tag = 1.0.0
+    if: tag =~ ^v1\.\d+(\.\d+)?$ # ex) v1.0.0
     env:
-      - CI_TRIGGER_ENV=prod CI_TRIGGER_TARGET=cms-restart
+      - CI_TRIGGER_ENV=prod
+      - CI_TRIGGER_TARGET=cms-restart
+      - CI_TRIGGER_TAG=${TRAVIS_TAG}
     script:
       - bin/deploy.sh
 
+  # deploy 2.x (prod)
   - stage: deploy
-    name: deploy-prod-v2
-    if: branch = 2.x AND tag =~ ^2\.\d+(\.\d+)?$ # ex) tag = 2.0.0
+    if: tag =~ ^v2\.\d+(\.\d+)?$ # ex) v2.0.0
     env:
-      - CI_TRIGGER_ENV=prod CI_TRIGGER_TARGET=cms-v2-restart
+      - CI_TRIGGER_ENV=prod
+      - CI_TRIGGER_TARGET=cms-v2-restart
+      - CI_TRIGGER_TAG=${TRAVIS_TAG}
     script:
       - bin/deploy.sh

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,4 +5,5 @@ curl -X POST \
     -F "ref=master" \
     -F "variables[ENV]=${CI_TRIGGER_ENV}" \
     -F "variables[TARGET]=${CI_TRIGGER_TARGET}" \
+    -F "variables[TAG]=${CI_TRIGGER_TAG}" \
     https://gitlab.ridi.io/api/v4/projects/329/trigger/pipeline

--- a/bin/docker_push.sh
+++ b/bin/docker_push.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-DOCKER_TAG=${TRAVIS_TAG:-latest}
-COMMIT=${TRAVIS_COMMIT::8}
+DOCKER_TAG=${DOCKER_TAG:-latest}
+DEFAULT_TAG=$(git rev-parse --short HEAD) # commit hash
 
 docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-docker build -t ridibooks/cms:${COMMIT} .
 
-echo "Pushing ridibooks/cms"
-docker tag ridibooks/cms:${COMMIT} ridibooks/cms:${DOCKER_TAG}
+echo "Bulilding ridibooks/cms..."
+docker build -t ridibooks/cms:${DEFAULT_TAG} .
+echo "Builded ridibooks/cms"
+
+echo "Pushing ridibooks/cms..."
+docker tag ridibooks/cms:${DEFAULT_TAG} ridibooks/cms:${DOCKER_TAG}
 docker push ridibooks/cms
 echo "Pushed ridibooks/cms"


### PR DESCRIPTION
## 이슈
Git release시 (tag push할 때) Travis에서 event type = push 조건을 통과하지 못해서 deploy단계가 skip되는 문제를 수정했습니다.

## 의도
기존에 배포할 때 branch이름(1.x, 2.x)을 latest같이 사용하고 있었습니다.  
하지만 release시엔 Travis에 branch정보가 전달되지 않아 문제가 생겼습니다. (당연히 전달될 줄 알고 작업)

전달된 release tag만으로 Docker image tag를 유추할 순 있지만.. 그런 규칙을 만드는 것보다는 release tag를 바로 사용해서 이미지를 빌드, 배포하는 게 자연스럽다고 생각했습니다.