### PR TITLE
Add /token-refresh endpoint 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "sentry/sentry": "^1.6",
     "silex/silex": "^2.0",
     "twig/twig": "^2.0.0",
-    "vlucas/phpdotenv": "^2.4"
+    "vlucas/phpdotenv": "^2.4",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {
     "robmorgan/phinx": "^0.9.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cf8763ae916f2e662dc3a69e5290a40",
+    "content-hash": "f03c25e86351dde957f86632be9c41e4",
     "packages": [
         {
             "name": "apache/thrift",

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -31,7 +31,7 @@ class LoginController implements ControllerProviderInterface
         $controller_collection->get('/logout', [$this, 'logout']);
 
         $controller_collection->post('/token-introspect', [$this, 'tokenIntrospect']);
-        $controller_collection->get('/token-refresh', [$this, 'tokenRefresh']);
+        $controller_collection->post('/token-refresh', [$this, 'tokenRefresh']);
 
         return $controller_collection;
     }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class LoginController implements ControllerProviderInterface
 {
+    /** @var AzureOAuth2Service */
     private $azure;
 
     public function connect(Application $app)

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class LoginController implements ControllerProviderInterface
 {
@@ -132,8 +133,15 @@ class LoginController implements ControllerProviderInterface
 
     public function tokenRefresh(Request $request, Application $app)
     {
+        $redirect_url = $request->get('redirect_url');
         $refresh_token = $request->cookies->get(LoginService::REFRESH_COOKIE_NAME);
 
-        return LoginService::refreshToken($refresh_token, $app['azure']);
+        try {
+            $response = LoginService::refreshToken($redirect_url, $refresh_token, $app['azure']);
+        } catch (\Exception $e) {
+            $redirect_param = $redirect_url ? "?redirect_url=$redirect_url" : '';
+            $response = RedirectResponse::create('/login' . $redirect_param);
+        }
+        return $response;
     }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -31,6 +31,7 @@ class LoginController implements ControllerProviderInterface
         $controller_collection->get('/logout', [$this, 'logout']);
 
         $controller_collection->post('/token-introspect', [$this, 'tokenIntrospect']);
+        $controller_collection->get('/token-refresh', [$this, 'tokenRefresh']);
 
         return $controller_collection;
     }
@@ -127,5 +128,12 @@ class LoginController implements ControllerProviderInterface
             $token_resource = AzureOAuth2Service::introspectToken($token, $app['azure']);
         }
         return JsonResponse::create($token_resource);
+    }
+
+    public function tokenRefresh(Request $request, Application $app)
+    {
+        $refresh_token = $request->cookies->get(LoginService::REFRESH_COOKIE_NAME);
+
+        return LoginService::refreshToken($refresh_token, $app['azure']);
     }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -133,15 +133,13 @@ class LoginController implements ControllerProviderInterface
 
     public function tokenRefresh(Request $request, Application $app)
     {
-        $redirect_url = $request->get('redirect_url');
+        $return_url = $request->get('return_url', '/welcome');
         $refresh_token = $request->cookies->get(LoginService::REFRESH_COOKIE_NAME);
 
-        try {
-            $response = LoginService::refreshToken($redirect_url, $refresh_token, $app['azure']);
-        } catch (\Exception $e) {
-            $redirect_param = $redirect_url ? "?redirect_url=$redirect_url" : '';
-            $response = RedirectResponse::create('/login' . $redirect_param);
+        if (empty($refresh_token)) {
+            return RedirectResponse::create("/login?return_url=$return_url");
         }
-        return $response;
+
+        return LoginService::refreshToken($return_url, $refresh_token, $app['azure']);
     }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -120,7 +120,8 @@ class LoginController implements ControllerProviderInterface
         } else {
             $token_resource = $this->azure->introspectToken($token);
         }
-        return JsonResponse::create($token_resource);
+        return JsonResponse::create($token_resource,
+            isset($token_resource['error']) ? Response::HTTP_BAD_REQUEST: Response::HTTP_OK);
     }
 
     public function tokenRefresh(Request $request, Application $app)

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -31,7 +31,7 @@ class LoginController implements ControllerProviderInterface
         $controller_collection->get('/logout', [$this, 'logout']);
 
         $controller_collection->post('/token-introspect', [$this, 'tokenIntrospect']);
-        $controller_collection->post('/token-refresh', [$this, 'tokenRefresh']);
+        $controller_collection->get('/token-refresh', [$this, 'tokenRefresh']);
 
         return $controller_collection;
     }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -23,7 +23,6 @@ class LoginController implements ControllerProviderInterface
 
         // login page
         $controller_collection->get('/login', [$this, 'getLoginPage']);
-        $controller_collection->get('/login-authorize', [$this, 'loginAuthorize']);
 
         // login process
         $controller_collection->get('/login-azure', [$this, 'azureLogin']);
@@ -32,7 +31,7 @@ class LoginController implements ControllerProviderInterface
         $controller_collection->get('/logout', [$this, 'logout']);
 
         $controller_collection->post('/token-introspect', [$this, 'tokenIntrospect']);
-        $controller_collection->get('/token-refresh', [$this, 'tokenRefresh']);
+        $controller_collection->match('/token-refresh', [$this, 'tokenRefresh']);
 
         return $controller_collection;
     }
@@ -48,17 +47,6 @@ class LoginController implements ControllerProviderInterface
         return $app->render('login.twig', [
             'azure_login' => $end_point
         ], $response);
-    }
-
-    public function loginAuthorize(Request $request, Application $app)
-    {
-        $end_point = $this->buildAuthorizeEndpoint($request, $app);
-
-        $response = RedirectResponse::create($end_point);
-        $return_url = $request->get('return_url', '/welcome');
-        $response->headers->setCookie(new Cookie('return_url', $return_url));
-
-        return $response;
     }
 
     private function buildAuthorizeEndpoint(Request $request, Application $app)

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -87,7 +87,7 @@ class LoginController implements ControllerProviderInterface
             if (!empty($app['test_id'])) {
                 $response = LoginService::handleTestLogin($return_url, $app['test_id']);
             } else {
-                $response = LoginService::handleAzureLogin($return_url, $code, $app['azure']);
+                $response = LoginService::handleAzureLogin($return_url, $code, $this->azure);
             }
         } catch (\Exception $e) {
             return UrlHelper::printAlertRedirect($return_url, $e->getMessage());

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -24,7 +24,7 @@ class AzureOAuth2Service
             . "post_logout_redirect_uri=" . urlencode($redirect_url);
     }
 
-    public static function requestAccessToken($code, $azure_config)
+    public static function requestToken($code, $azure_config)
     {
         $tenent = $azure_config['tenent'];
         $client_id = $azure_config['client_id'];
@@ -76,15 +76,20 @@ class AzureOAuth2Service
         return json_decode($output);
     }
 
-    public static function getAccessToken(string $code, array $azure_config): string
+    public static function getTokens(string $code, array $azure_config): array
     {
-        $tokenOutput = self::requestAccessToken($code, $azure_config);
+        $tokenOutput = self::requestToken($code, $azure_config);
         $token_type = $tokenOutput->token_type;
         $access_token = $tokenOutput->access_token;
         if (!$token_type || !$access_token) {
             throw new \Exception("[requestAccessToken]\n $tokenOutput->error: $tokenOutput->error_description");
         }
-        return $tokenOutput->access_token;
+
+        return [
+            "access" => $access_token,
+            "refresh" => $tokenOutput->refresh_token,
+            "expires_on" => $tokenOutput->expires_on,
+        ];
     }
 
     public static function introspectToken(string $access_token, array $azure_config): array

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -76,7 +76,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * throw Exception
+     * @throws Exception
      */
     public function getTokens(string $code): array
     {
@@ -101,7 +101,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * throw Exception
+     * @throws Exception
      */
     public function refreshToken(string $refresh_token): array
     {
@@ -123,7 +123,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * throw Exception
+     * @throws Exception
      */
     private function parseTokenReource($token_resource): array
     {

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -12,6 +12,8 @@ class AzureOAuth2Service
     private $redirect_uri;
     private $resource;
     private $api_version;
+
+    /** @var Client */
     private $http;
 
     public function __construct(array $azure_config, array $guzzle_config = [])
@@ -79,7 +81,7 @@ class AzureOAuth2Service
     public function getTokens(string $code): array
     {
         $token_resource = self::requestToken($code);
-        return self::verifyTokenResponse($token_resource);
+        return self::parseTokenReource($token_resource);
     }
 
     public function introspectToken(string $access_token): array
@@ -117,13 +119,13 @@ class AzureOAuth2Service
 
         $token_resource = json_decode($response->getBody());
 
-        return self::verifyTokenResponse($token_resource);
+        return self::parseTokenReource($token_resource);
     }
 
     /**
      * throw Exception
      */
-    private function verifyTokenResponse($token_resource): array
+    private function parseTokenReource($token_resource): array
     {
         $token_type = $token_resource->token_type;
         $access_token = $token_resource->access_token;

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -2,6 +2,8 @@
 
 namespace Ridibooks\Cms\Lib;
 
+use GuzzleHttp\Client;
+
 class AzureOAuth2Service
 {
     public static function getAuthorizeEndPoint($azure_config)
@@ -78,18 +80,8 @@ class AzureOAuth2Service
 
     public static function getTokens(string $code, array $azure_config): array
     {
-        $tokenOutput = self::requestToken($code, $azure_config);
-        $token_type = $tokenOutput->token_type;
-        $access_token = $tokenOutput->access_token;
-        if (!$token_type || !$access_token) {
-            throw new \Exception("[requestAccessToken]\n $tokenOutput->error: $tokenOutput->error_description");
-        }
-
-        return [
-            "access" => $access_token,
-            "refresh" => $tokenOutput->refresh_token,
-            "expires_on" => $tokenOutput->expires_on,
-        ];
+        $token_resource = self::requestToken($code, $azure_config);
+        return self::verifyTokenResponse($token_resource);
     }
 
     public static function introspectToken(string $access_token, array $azure_config): array
@@ -105,6 +97,44 @@ class AzureOAuth2Service
         return [
             'user_id' => $azure_resource->mailNickname,
             'user_name' => $azure_resource->displayName,
+        ];
+    }
+
+    public static function refreshToken(string $refresh_token, $azure_config): array
+    {
+        $endpoint = "https://login.microsoftonline.com/{$azure_config['tenent']}/oauth2/token";
+        $client = new Client(['verify' => false]);
+        $response = $client->post($endpoint, [
+            'form_params' => [
+                'grant_type' => 'refresh_token' ,
+                'client_id' => $azure_config['client_id'],
+                'client_secret' => $azure_config['client_secret'],
+                'resource' => $azure_config['resource'],
+                'refresh_token' => $refresh_token,
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $token_resource = json_decode($response->getBody()->getContents());
+
+        return self::verifyTokenResponse($token_resource);
+    }
+
+    private static function verifyTokenResponse($token_resource)
+    {
+        $token_type = $token_resource->token_type;
+        $access_token = $token_resource->access_token;
+        if (!$token_type || !$access_token) {
+            throw new \Exception("[requestAccessToken]\n $token_resource->error: $token_resource->error_description");
+        }
+
+        return [
+            "access" => $access_token,
+            "refresh" => $token_resource->refresh_token,
+            "expires_on" => $token_resource->expires_on,
         ];
     }
 }

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -31,6 +31,7 @@ class AzureOAuth2Service
         $endpoint = "https://login.microsoftonline.com/{$azure_config['tenent']}/oauth2/token";
         $client = new Client(['verify' => false]);
         $response = $client->post($endpoint, [
+            'http_errors' => false,
             'form_params' => [
                 'grant_type' => 'authorization_code' ,
                 'client_id' => $azure_config['client_id'],
@@ -40,11 +41,7 @@ class AzureOAuth2Service
             ],
         ]);
 
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception("[requestToken]\nCode: {$response->getStatusCode()}");
-        }
-
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody());
     }
 
     public static function requestResource($tokenType, $accessToken, $azure_config)
@@ -56,19 +53,16 @@ class AzureOAuth2Service
         $endpoint = "$resource/$tenent/me/?api-version=$api_version";
         $client = new Client(['verify' => false]);
         $response = $client->get($endpoint, [
+            'http_errors' => false,
             'headers' => [
                 'Authorization' => "$tokenType $accessToken",
-                'Accept' => 'application/json',
+                'Accept' => 'application/json;odata=minimalmetadata',
                 'odata' => 'minimalmetadata',
                 'Content-Type' => 'application/json',
             ],
         ]);
 
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception("[requestResource]\nCode: {$response->getStatusCode()}");
-        }
-
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody());
     }
 
     public static function getTokens(string $code, array $azure_config): array
@@ -98,6 +92,7 @@ class AzureOAuth2Service
         $endpoint = "https://login.microsoftonline.com/{$azure_config['tenent']}/oauth2/token";
         $client = new Client(['verify' => false]);
         $response = $client->post($endpoint, [
+            'http_errors' => false,
             'form_params' => [
                 'grant_type' => 'refresh_token' ,
                 'client_id' => $azure_config['client_id'],
@@ -107,11 +102,7 @@ class AzureOAuth2Service
             ],
         ]);
 
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception("[refreshToken]\nCode: {$response->getStatusCode()}");
-        }
-
-        $token_resource = json_decode($response->getBody()->getContents());
+        $token_resource = json_decode($response->getBody());
 
         return self::verifyTokenResponse($token_resource);
     }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -81,9 +81,9 @@ class LoginService
         return $response;
     }
 
-    private static function createLogoutResponse(string $redirect_url): Response
+    private static function createLogoutResponse(string $return_url): Response
     {
-        $response = RedirectResponse::create($redirect_url);
+        $response = RedirectResponse::create($return_url);
         $response->headers->clearCookie(self::ADMIN_ID_COOKIE_NAME);
         $response->headers->clearCookie(self::TOKEN_COOKIE_NAME);
         $response->headers->clearCookie(self::REFRESH_COOKIE_NAME);
@@ -95,11 +95,11 @@ class LoginService
         return $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
     }
 
-    public static function refreshToken(string $redirect_url, $refresh_token, $azure_config): Response
+    public static function refreshToken(string $return_url, $refresh_token, $azure_config): Response
     {
         $tokens = AzureOAuth2Service::refreshToken($refresh_token, $azure_config);
 
-        $response = RedirectResponse::create($redirect_url);
+        $response = RedirectResponse::create($return_url);
         $cookies = self::createLoginCookies($tokens);
         return self::setCookies($response, $cookies);
     }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -38,7 +38,7 @@ class LoginService
             'expires_on' => 60 * 60 * 24 * 30, // 30 days
         ];
 
-        return createLoginResponse($return_url, $tokens, $test_id);
+        return self::createLoginResponse($return_url, $tokens, $test_id);
     }
 
     /**
@@ -54,7 +54,7 @@ class LoginService
 
         self::login($resource['user_id'], $resource['user_name']);
 
-        return createLoginResponse($return_url, $tokens, $resource['user_id']);
+        return self::createLoginResponse($return_url, $tokens, $resource['user_id']);
     }
 
     public static function createLoginResponse(string $return_url, array $tokens, ?string $login_id = null): Response

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -13,7 +13,7 @@ class LoginService
     const TOKEN_COOKIE_NAME = 'cms-token';
     const REFRESH_COOKIE_NAME = 'cms-refresh';
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
-    const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 7; // 7 days
+    const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 30; // 30 days
 
     public static function login($user_id, $user_name)
     {

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -95,11 +95,11 @@ class LoginService
         return $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
     }
 
-    public static function refreshToken($refresh_token, $azure_config): Response
+    public static function refreshToken(string $redirect_url, $refresh_token, $azure_config): Response
     {
         $tokens = AzureOAuth2Service::refreshToken($refresh_token, $azure_config);
 
-        $response = Response::create();
+        $response = RedirectResponse::create($redirect_url);
         $cookies = self::createLoginCookies($tokens);
         return self::setCookies($response, $cookies);
     }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -11,8 +11,9 @@ use Symfony\Component\HttpFoundation\Response;
 class LoginService
 {
     const TOKEN_COOKIE_NAME = 'cms-token';
+    const REFRESH_COOKIE_NAME = 'cms-refresh';
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
-    const TOKEN_EXPIRES_SEC = 60 * 60 * 12; // 12hours
+    const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 7; // 7 days
 
     public static function login($user_id, $user_name)
     {
@@ -33,15 +34,15 @@ class LoginService
 
     public static function handleAzureLogin(string $return_url, string $code, $azure_config): Response
     {
-        $token = AzureOAuth2Service::getAccessToken($code, $azure_config);
-        $resource = AzureOAuth2Service::introspectToken($token, $azure_config);
+        $tokens = AzureOAuth2Service::getTokens($code, $azure_config);
+        $resource = AzureOAuth2Service::introspectToken($tokens['access'], $azure_config);
         if (isset($resource['error']) || isset($resource['message'])) {
             throw new \Exception("[requestResource]\n {$resource['error']}: {$resource['message']}");
         }
 
         self::login($resource['user_id'], $resource['user_name']);
 
-        return self::createLoginResponse($return_url, $resource['user_id'], $token);
+        return self::createLoginResponse($return_url, $resource['user_id'], $tokens['access'], $tokens['refresh'], $tokens['expires_on']);
     }
 
     public static function handleLogout(string $redirect_url): Response
@@ -49,16 +50,18 @@ class LoginService
         return self::createLogoutResponse($redirect_url);
     }
 
-    private static function createLoginResponse(string $return_url, string $login_id, string $token): Response
+    private static function createLoginResponse(string $return_url, string $login_id, string $token, string $refresh, int $expires_on): Response
     {
-        $expire = time() + self::TOKEN_EXPIRES_SEC;
+        $refresh_token_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
         $secure = empty($_ENV['DEBUG']) ? true : false;
-        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $expire, '/', null, $secure, true);
-        $token_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $token, $expire, '/', null, $secure, true);
+        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $expires_on, '/', null, $secure, true);
+        $token_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $token, $expires_on, '/', null, $secure, true);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh, $refresh_token_expires_on, '/token-refresh', null, $secure, true);
 
         $response = RedirectResponse::create($return_url);
         $response->headers->setCookie($login_id_cookie);
         $response->headers->setCookie($token_cookie);
+        $response->headers->setCookie($refresh_cookie);
         return $response;
     }
 

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -15,7 +15,10 @@ class LoginService
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
     const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 30; // 30 days
 
-    public static function login($user_id, $user_name)
+    /**
+     * @throws Exception
+     */
+    public static function login(string $user_id, string $user_name)
     {
         $user_service = new AdminUserService();
         $user = $user_service->getUser($user_id);
@@ -27,18 +30,20 @@ class LoginService
         }
     }
 
-    public static function handleTestLogin($return_url, $test_id): Response
+    public static function handleTestLogin(string $return_url, string $test_id): Response
     {
-        $response = RedirectResponse::create($return_url);
         $tokens = [
             'access' => 'test',
             'refresh' => 'test',
             'expires_on' => 60 * 60 * 24 * 30, // 30 days
         ];
-        $cookies =  self::createLoginCookies($tokens, 'test');
-        return self::setCookies($response, $cookies);
+
+        return createLoginResponse($return_url, $tokens, $test_id);
     }
 
+    /**
+     * @throws Exception
+     */
     public static function handleAzureLogin(string $return_url, string $code,  AzureOAuth2Service $azure): Response
     {
         $tokens = $azure->getTokens($code);
@@ -49,9 +54,17 @@ class LoginService
 
         self::login($resource['user_id'], $resource['user_name']);
 
+        return createLoginResponse($return_url, $tokens, $resource['user_id']);
+    }
+
+    public static function createLoginResponse(string $return_url, array $tokens, ?string $login_id = null): Response
+    {
         $response = RedirectResponse::create($return_url);
-        $cookies = self::createLoginCookies($tokens, $resource['user_id']);
-        return self::setCookies($response, $cookies);
+        $cookies = self::createLoginCookies($tokens['access'], $tokens['refresh'], $tokens['expires_on'], $login_id);
+        foreach($cookies as $cookie) {
+            $response->headers->setCookie($cookie);
+        }
+        return $response;
     }
 
     public static function handleLogout(string $redirect_url): Response
@@ -59,16 +72,12 @@ class LoginService
         return self::createLogoutResponse($redirect_url);
     }
 
-    private static function createLoginCookies(array $tokens, ?string $login_id = null): array
+    private static function createLoginCookies(string $token, string $refresh_token, string $expires_on, ?string $login_id = null): array
     {
-        $token = $tokens['access'];
-        $refresh = $tokens['refresh'];
-        $expires_on = $tokens['expires_on'];
-
         $refresh_token_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
         $secure = empty($_ENV['DEBUG']) ? true : false;
         $token_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $token, $expires_on, '/', null, $secure, true);
-        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh, $refresh_token_expires_on, '/token-refresh', null, $secure, true);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, $refresh_token_expires_on, '/token-refresh', null, $secure, true);
 
         $login_id_cookie = null;
         if (isset($login_id)) {
@@ -76,14 +85,6 @@ class LoginService
         }
 
         return array_filter([$token_cookie, $refresh_cookie, $login_id_cookie]);
-    }
-
-    private static function setCookies(Response $response, array $cookies): Response
-    {
-        foreach($cookies as $cookie) {
-            $response->headers->setCookie($cookie);
-        }
-        return $response;
     }
 
     private static function createLogoutResponse(string $return_url): Response
@@ -104,8 +105,6 @@ class LoginService
     {
         $tokens = $azure->refreshToken($refresh_token);
 
-        $response = RedirectResponse::create($return_url);
-        $cookies = self::createLoginCookies($tokens);
-        return self::setCookies($response, $cookies);
+        return self::createLoginResponse($return_url, $tokens);
     }
 }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -34,10 +34,10 @@ class LoginService
         return self::setCookies($response, $cookies);
     }
 
-    public static function handleAzureLogin(string $return_url, string $code, $azure_config): Response
+    public static function handleAzureLogin(string $return_url, string $code,  AzureOAuth2Service $azure): Response
     {
-        $tokens = AzureOAuth2Service::getTokens($code, $azure_config);
-        $resource = AzureOAuth2Service::introspectToken($tokens['access'], $azure_config);
+        $tokens = $azure->getTokens($code);
+        $resource = $azure->introspectToken($tokens['access']);
         if (isset($resource['error']) || isset($resource['message'])) {
             throw new \Exception("[requestResource]\n {$resource['error']}: {$resource['message']}");
         }
@@ -95,9 +95,9 @@ class LoginService
         return $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
     }
 
-    public static function refreshToken(string $return_url, $refresh_token, $azure_config): Response
+    public static function refreshToken(string $return_url, $refresh_token, AzureOAuth2Service $azure): Response
     {
-        $tokens = AzureOAuth2Service::refreshToken($refresh_token, $azure_config);
+        $tokens = $azure->refreshToken($refresh_token);
 
         $response = RedirectResponse::create($return_url);
         $cookies = self::createLoginCookies($tokens);

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -30,6 +30,11 @@ class LoginService
     public static function handleTestLogin($return_url, $test_id): Response
     {
         $response = RedirectResponse::create($return_url);
+        $tokens = [
+            'access' => 'test',
+            'refresh' => 'test',
+            'expires_on' => 60 * 60 * 24 * 30, // 30 days
+        ];
         $cookies =  self::createLoginCookies($tokens, 'test');
         return self::setCookies($response, $cookies);
     }

--- a/tests/AzureOAuth2ServiceTest.php
+++ b/tests/AzureOAuth2ServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Ridibooks\Cms\Lib;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class AzureOAuth2ServiceTest extends TestCase
+{
+    private $config = [
+        'tenent' => 'ridicorp.com',
+        'client_id' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+        'client_secret' => 'ffffffffffffffffffffffffffffffffffffffffffff',
+        'resource' => 'https://graph.windows.net',
+        'redirect_uri' => 'https://admin.ridibooks.com/login-azure',
+        'api_version' => '2013-11-08',
+    ];
+
+    private $token_response = [
+        "access_token" => "eyJ0eXAiOiJ",
+        "token_type" => "Bearer",
+        "expires_in" => "3600",
+        "expires_on" => "1388444763",
+        "resource" => "https://service.contoso.com/",
+        "refresh_token" => "AwABAAAAvPM1KaPlrEqdFSBzjqfTGAxA",
+        "scope" => "https%3A%2F%2Fgraph.microsoft.com%2Fmail.read",
+    ]; 
+
+    public function testGetAuthorizeEndPoint()
+    {
+        $azure = new AzureOAuth2Service($this->config);
+
+        $endpoint = $azure->getAuthorizeEndPoint();
+        $this->assertStringStartsWith('https://login.windows.net', $endpoint);
+        $this->assertRegexp("/{$this->config['tenent']}/", $endpoint);
+        $this->assertRegexp("/response_type=code/", $endpoint);
+        $this->assertRegexp("/client_id={$this->config['client_id']}/", $endpoint);
+        $this->assertRegexp("/resource=" . urlencode($this->config['resource']) . "/", $endpoint);
+        $this->assertRegexp("/redirect_uri=" . urlencode($this->config['redirect_uri']) . "/", $endpoint);
+    }
+
+    public function testGetTokens()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($this->token_response)),
+        ]);
+        $guzzle_handler = HandlerStack::create($mock);
+
+        $azure = new AzureOAuth2Service($this->config, ['handler' => $guzzle_handler]);
+
+        $tokens = $azure->getTokens('1234');
+        $this->assertEquals($tokens['access'], $this->token_response['access_token']);
+        $this->assertEquals($tokens['refresh'], $this->token_response['refresh_token']);
+        $this->assertEquals($tokens['expires_on'], $this->token_response['expires_on']);
+    }
+
+    public function testRefreshToken()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($this->token_response)),
+        ]);
+        $guzzle_handler = HandlerStack::create($mock);
+
+        $azure = new AzureOAuth2Service($this->config, ['handler' => $guzzle_handler]);
+
+        $tokens = $azure->refreshToken('1234');
+        $this->assertEquals($tokens['access'], $this->token_response['access_token']);
+        $this->assertEquals($tokens['refresh'], $this->token_response['refresh_token']);
+        $this->assertEquals($tokens['expires_on'], $this->token_response['expires_on']);
+    }
+}


### PR DESCRIPTION
토큰 만료시 /token-refresh 에서 연장하도록 수정하였습니다.
https://app.asana.com/0/235684600038401/600156742639752

## 변경내용
* /token-refresh 추가
* /login-authorize 제거
* 로그인시 Refresh 토큰 저장
* curl 사용로직 GuzzleHttp로 리펙터링

## 고려 사항
`/token-refresh`가 쿠키의 토큰 값들을 변경해야함에도 GET으로 구현해야 했습니다. 
이유는 `/token-refresh`가  User Agent의 redirect를 통해 접근되고 있기 때문입니다. (Refresh 토큰 쿠키가 `/token-refresh`에서만 접근가능하기 때문에 Server Side에서 호출이 불가능합니다.)
이는 `/token-introspect`가 Server Side에서 POST로 호출되는것과 차이가 있습니다.