### PR TITLE
Fix the broken test mode (wrong expired time)

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -11,9 +11,9 @@ use Silex\Api\ControllerProviderInterface;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class LoginController implements ControllerProviderInterface
 {
@@ -100,7 +100,11 @@ class LoginController implements ControllerProviderInterface
     public function logout(Request $request, Application $app)
     {
         $redirect_url = $request->getUriForPath('/login');
-        $endpoint = $this->azure->getLogoutEndpoint($redirect_url);
+        if (!empty($app['test_id'])) {
+            $endpoint = $redirect_url;
+        } else {
+            $endpoint = $this->azure->getLogoutEndpoint($redirect_url);
+        }
 
         return LoginService::handleLogout($endpoint);
     }
@@ -121,7 +125,7 @@ class LoginController implements ControllerProviderInterface
             $token_resource = $this->azure->introspectToken($token);
         }
         return JsonResponse::create($token_resource,
-            isset($token_resource['error']) ? Response::HTTP_BAD_REQUEST: Response::HTTP_OK);
+            isset($token_resource['error']) ? Response::HTTP_BAD_REQUEST : Response::HTTP_OK);
     }
 
     public function tokenRefresh(Request $request, Application $app)

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -49,7 +49,7 @@ class AzureOAuth2Service
         $response = $this->http->post($endpoint, [
             'http_errors' => false,
             'form_params' => [
-                'grant_type' => 'authorization_code' ,
+                'grant_type' => 'authorization_code',
                 'client_id' => $this->client_id,
                 'client_secret' => $this->client_secret,
                 'redirect_uri' => $this->redirect_uri,
@@ -76,7 +76,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * @throws Exception
+     * @throws \Exception
      */
     public function getTokens(string $code): array
     {
@@ -101,7 +101,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * @throws Exception
+     * @throws \Exception
      */
     public function refreshToken(string $refresh_token): array
     {
@@ -109,7 +109,7 @@ class AzureOAuth2Service
         $response = $this->http->post($endpoint, [
             'http_errors' => false,
             'form_params' => [
-                'grant_type' => 'refresh_token' ,
+                'grant_type' => 'refresh_token',
                 'client_id' => $this->client_id,
                 'client_secret' => $this->client_secret,
                 'resource' => $this->resource,
@@ -123,7 +123,7 @@ class AzureOAuth2Service
     }
 
     /**
-     * @throws Exception
+     * @throws \Exception
      */
     private function parseTokenReource($token_resource): array
     {

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -15,10 +15,47 @@ class LoginService
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
     const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 30; // 30 days
 
+    const TEST_TOKEN_EXPIRES_SEC = 60 * 60; // 1 hour
+
+    public static function handleTestLogin(string $return_url, string $test_id): Response
+    {
+        $access_expires_on = time() + self::TEST_TOKEN_EXPIRES_SEC;
+        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        return self::createLoginResponse(
+            $return_url,
+            'test',
+            $access_expires_on,
+            'test',
+            $refresh_expires_on,
+            $test_id
+        );
+    }
+
     /**
-     * @throws Exception
+     * @throws \Exception
      */
-    public static function login(string $user_id, string $user_name)
+    public static function handleAzureLogin(string $return_url, string $code, AzureOAuth2Service $azure): Response
+    {
+        $tokens = $azure->getTokens($code);
+        $access_token = $tokens['access'];
+        $expires_on = $tokens['expires_on'];
+        $refresh_token = $tokens['refresh'];
+
+        $resource = $azure->introspectToken($access_token);
+        if (isset($resource['error']) || isset($resource['message'])) {
+            throw new \Exception("[requestResource]\n {$resource['error']}: {$resource['message']}");
+        }
+
+        self::addUserIfNotExists($resource['user_id'], $resource['user_name']);
+
+        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        return self::createLoginResponse($return_url, $access_token, $expires_on, $refresh_token, $refresh_expires_on, $resource['user_id']);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private static function addUserIfNotExists(string $user_id, string $user_name)
     {
         $user_service = new AdminUserService();
         $user = $user_service->getUser($user_id);
@@ -30,61 +67,27 @@ class LoginService
         }
     }
 
-    public static function handleTestLogin(string $return_url, string $test_id): Response
-    {
-        $tokens = [
-            'access' => 'test',
-            'refresh' => 'test',
-            'expires_on' => 60 * 60 * 24 * 30, // 30 days
-        ];
-
-        return self::createLoginResponse($return_url, $tokens, $test_id);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public static function handleAzureLogin(string $return_url, string $code,  AzureOAuth2Service $azure): Response
-    {
-        $tokens = $azure->getTokens($code);
-        $resource = $azure->introspectToken($tokens['access']);
-        if (isset($resource['error']) || isset($resource['message'])) {
-            throw new \Exception("[requestResource]\n {$resource['error']}: {$resource['message']}");
-        }
-
-        self::login($resource['user_id'], $resource['user_name']);
-
-        return self::createLoginResponse($return_url, $tokens, $resource['user_id']);
-    }
-
-    public static function createLoginResponse(string $return_url, array $tokens, ?string $login_id = null): Response
+    public static function createLoginResponse(string $return_url, string $access_token, int $access_expires_on, string $refresh_token, int $refresh_expires_on, ?string $login_id = null): Response
     {
         $response = RedirectResponse::create($return_url);
-        $cookies = self::createLoginCookies($tokens['access'], $tokens['refresh'], $tokens['expires_on'], $login_id);
-        foreach($cookies as $cookie) {
-            $response->headers->setCookie($cookie);
+
+        $is_secure = empty($_ENV['DEBUG']) ? true : false;
+        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', null, $is_secure);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, $refresh_expires_on, '/v2/token-refresh', null, $is_secure);
+        $response->headers->setCookie($access_cookie);
+        $response->headers->setCookie($refresh_cookie);
+
+        if (isset($login_id)) {
+            $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', null, $is_secure);
+            $response->headers->setCookie($login_id_cookie);
         }
+
         return $response;
     }
 
     public static function handleLogout(string $redirect_url): Response
     {
         return self::createLogoutResponse($redirect_url);
-    }
-
-    private static function createLoginCookies(string $token, string $refresh_token, string $expires_on, ?string $login_id = null): array
-    {
-        $refresh_token_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
-        $secure = empty($_ENV['DEBUG']) ? true : false;
-        $token_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $token, $expires_on, '/', null, $secure, true);
-        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, $refresh_token_expires_on, '/v2/token-refresh', null, $secure, true);
-
-        $login_id_cookie = null;
-        if (isset($login_id)) {
-            $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $expires_on, '/', null, $secure, true);
-        }
-
-        return array_filter([$token_cookie, $refresh_cookie, $login_id_cookie]);
     }
 
     private static function createLogoutResponse(string $return_url): Response
@@ -101,10 +104,25 @@ class LoginService
         return $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
     }
 
+    /**
+     * @throws \Exception
+     */
     public static function refreshToken(string $return_url, $refresh_token, AzureOAuth2Service $azure): Response
     {
-        $tokens = $azure->refreshToken($refresh_token);
+        if ($refresh_token === 'test') {
+            $tokens = [
+                'access' => 'test',
+                'refresh' => 'test',
+                'expires_on' => self::TEST_TOKEN_EXPIRES_SEC,
+            ];
+        } else {
+            $tokens = $azure->refreshToken($refresh_token);
+        }
 
-        return self::createLoginResponse($return_url, $tokens);
+        $access_token = $tokens['access'];
+        $refresh_token = $tokens['refresh'];
+        $access_expires_on = time() + $tokens['$expires_on'];
+        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        return self::createLoginResponse($return_url, $access_token, $access_expires_on, $refresh_token, $refresh_expires_on, null);
     }
 }


### PR DESCRIPTION
### 변경 의도 및 내용
환경변수 `TEST_ID` 가 설정되어 Azure로그인을 생략하도록 하면 제대로 로그인되지 않던 문제를 수정했습니다.

```php
// 문제가 된 부분 (기존 소스 L38)
// time() + 60 * 60 * 24 * 30 가 되어야 함
'expires_on' => 60 * 60 * 24 * 30
```

### 그 외 변경
- test인 경우는 로그아웃 시 Azure 로그아웃을 생략하도록 수정
- LoginService::login -> LoginService::addUserIfNotExists 이름 변경
  > 정확히 어떤 동작을 하는지, 의도를 가진 함수인지 애매해서
- LoginService::createLoginResponse와 Login::createLoginCookies 통합
  > array_filter와 루프를 제거하고, 명시적으로 setCookie를 반복 호출하는게 한 눈에 파악하기 좋다고 생각해서 (기존 소스 L64, L87)
- php-cs-fixer 적용