### PR TITLE
Fix token refresh failure due to cookie expiration

### DIFF
--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -19,14 +19,12 @@ class LoginService
 
     public static function handleTestLogin(string $return_url, string $test_id): Response
     {
-        $access_expires_on = time() + self::TEST_TOKEN_EXPIRES_SEC;
-        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        $login_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
         return self::createLoginResponse(
             $return_url,
             'test',
-            $access_expires_on,
             'test',
-            $refresh_expires_on,
+            $login_expires_on,
             $test_id
         );
     }
@@ -38,7 +36,6 @@ class LoginService
     {
         $tokens = $azure->getTokens($code);
         $access_token = $tokens['access'];
-        $expires_on = $tokens['expires_on'];
         $refresh_token = $tokens['refresh'];
 
         $resource = $azure->introspectToken($access_token);
@@ -48,8 +45,8 @@ class LoginService
 
         self::addUserIfNotExists($resource['user_id'], $resource['user_name']);
 
-        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
-        return self::createLoginResponse($return_url, $access_token, $expires_on, $refresh_token, $refresh_expires_on, $resource['user_id']);
+        $login_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        return self::createLoginResponse($return_url, $access_token, $refresh_token, $login_expires_on, $resource['user_id']);
     }
 
     /**
@@ -67,18 +64,19 @@ class LoginService
         }
     }
 
-    public static function createLoginResponse(string $return_url, string $access_token, int $access_expires_on, string $refresh_token, int $refresh_expires_on, ?string $login_id = null): Response
+    public static function createLoginResponse(string $return_url, string $access_token, string $refresh_token,
+        int $login_expires_on, ?string $login_id = null): Response
     {
         $response = RedirectResponse::create($return_url);
 
         $is_secure = empty($_ENV['DEBUG']) ? true : false;
-        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', null, $is_secure);
-        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, $refresh_expires_on, '/v2/token-refresh', null, $is_secure);
+        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $login_expires_on, '/', null, $is_secure);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, $login_expires_on, '/v2/token-refresh', null, $is_secure);
         $response->headers->setCookie($access_cookie);
         $response->headers->setCookie($refresh_cookie);
 
         if (isset($login_id)) {
-            $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', null, $is_secure);
+            $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $login_expires_on, '/', null, $is_secure);
             $response->headers->setCookie($login_id_cookie);
         }
 
@@ -121,8 +119,7 @@ class LoginService
 
         $access_token = $tokens['access'];
         $refresh_token = $tokens['refresh'];
-        $access_expires_on = time() + $tokens['$expires_on'];
-        $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
-        return self::createLoginResponse($return_url, $access_token, $access_expires_on, $refresh_token, $refresh_expires_on, null);
+        $login_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
+        return self::createLoginResponse($return_url, $access_token, $refresh_token, $login_expires_on, null);
     }
 }


### PR DESCRIPTION
Access Token 쿠키의 유효기간이 token자체의 유효기간과 같아서 유효기간 만료체크가되지 않고 바로 로그인으로 이동되고 있는 문제를 수정했습니다.

동시에 기존에는 개별쿠키에 유효기간을 세팅하던 것에서, 로그인에 대한 유효기간에 맞추어 모두 동일하게 변경했습니다. (`$login_expires_on`) 그리고 이 로그인의 유효기간은 refresh token의 유효기간과 동일하게 볼수 있으므로 refresh token의 유효기간에서 가져옵니다.