### PR TITLE
Add `getAdminTag` api

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -14,4 +14,4 @@ else
 fi
 
 vendor/bin/phinx migrate -e phinx_env
-vendor/bin/phinx seed:run -s User -s Menu -s MenuAjax -s UserMenu -e phinx_env
+vendor/bin/phinx seed:run -s User -s Menu -s MenuAjax -s UserMenu -s Tag -e phinx_env

--- a/phinx/seeds/Tag.php
+++ b/phinx/seeds/Tag.php
@@ -1,0 +1,22 @@
+<?php
+
+
+use Phinx\Seed\AbstractSeed;
+
+class Tag extends AbstractSeed
+{
+    public function run()
+    {
+        $data = [
+            [
+                'name' => '관리자그룹',
+                'is_use' => 1,
+                'creator' => 'admin',
+                'reg_date' => date('Y-m-d H:i:s'),
+            ],
+        ];
+
+        $posts = $this->table('tb_admin2_tag');
+        $posts->insert($data)->save();
+    }
+}

--- a/src/Service/AdminTagService.php
+++ b/src/Service/AdminTagService.php
@@ -3,6 +3,7 @@ namespace Ridibooks\Cms\Service;
 
 use Ridibooks\Cms\Model\AdminTag;
 use Ridibooks\Cms\Thrift\AdminTag\AdminTagServiceIf;
+use Ridibooks\Cms\Thrift\AdminTag\AdminTag as ThriftAdminTag;
 use Ridibooks\Cms\Thrift\ThriftService;
 
 class AdminTagService implements AdminTagServiceIf
@@ -38,5 +39,16 @@ class AdminTagService implements AdminTagServiceIf
         $menus = $admin_service->getMenus($menu_ids);
         $menus = ThriftService::convertMenuCollectionToArray($menus);
         return AdminAuthService::getHashesFromMenus($check_url, $menus);
+    }
+    
+    public function getAdminTag($tag_id): ThriftAdminTag
+    {
+        /** @var AdminTag $tag */
+        $tag = AdminTag::find($tag_id);
+
+        if (empty($tag)) {
+            return new ThriftAdminTag();
+        }
+        return new ThriftAdminTag($tag->toArray());
     }
 }

--- a/tests/AdminTagServiceTest.php
+++ b/tests/AdminTagServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Service;
+
+use PHPUnit\Framework\TestCase;
+use Ridibooks\Cms\Service\AdminTagService;
+
+class AdminTagServiceTest extends TestCase
+{
+    public function testGetAdminTag()
+    {
+        $tag_service = new AdminTagService();
+        $tag = $tag_service->getAdminTag(1);
+
+        $this->assertNotEmpty($tag->id);
+    }
+}


### PR DESCRIPTION
https://github.com/ridi/cms-sdk/pull/44 를 CMS에 적용한 내용입니다.
CMS-SDK가 머지되면 composer.lock 업데이트후 이것도 merge할 생각입니다.