### PR TITLE
Fix auth bugs 180415

### DIFF
--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -59,10 +59,6 @@ class AdminAuthService
      */
     public function authorize(string $token, array $methods, string $check_url)
     {
-        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
-            return;
-        }
-
         if (empty($token)) {
             throw new NoTokenException([
                 'code' => ErrorCode::BAD_REQUEST,
@@ -86,6 +82,10 @@ class AdminAuthService
                 'code' => ErrorCode::BAD_REQUEST,
                 'message' => '잘못된 토큰입니다.',
             ]);
+        }
+
+        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
+            return;
         }
 
         if (!self::checkAuth($methods, $check_url, $token_resource['user_id'])) {

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -99,7 +99,7 @@ class AdminAuthService
     public function checkAuth(array $check_method, string $check_url, string $admin_id): bool
     {
         $parsed = parse_url($check_url);
-        $check_url = rtrim($parsed['path'], '/');
+        $check_url = rtrim($parsed['path']);
 
         if (!$this->isValidUser($admin_id)) {
             return false;
@@ -111,11 +111,7 @@ class AdminAuthService
 
         $auth_list = $this->readUserAuth($admin_id);
         foreach ($auth_list as $auth) {
-            // If auth is not form of regex..
-            if (!preg_match("/^\/[\s\S]+\/$/", $auth)) {
-                $auth = '/' . preg_quote($auth, '/') . '/';
-            }
-
+            $auth = '/' . preg_quote($auth, '/') . '/';
             if (preg_match($auth, $check_url) === 1) {
                 return true;
             }

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -111,12 +111,23 @@ class AdminAuthService
 
         $auth_list = $this->readUserAuth($admin_id);
         foreach ($auth_list as $auth) {
-            $auth = '/' . preg_quote($auth, '/') . '/';
-            if (preg_match($auth, $check_url) === 1) {
+            if ($this->isAuthUrl($check_url, $auth)) {
                 return true;
             }
         }
 
+        return false;
+    }
+
+    private function isAuthUrl($check_url, $menu_url)
+    {
+        $auth_url = preg_replace('/(\?|#).*/', '', $menu_url);
+        if (strpos($check_url, '/comm/')) { // /comm/으로 시작하는 url은 권한을 타지 않는다.
+            return true;
+        }
+        if ($auth_url != '' && strpos($check_url, $auth_url) !== false) { //현재 url과 권한 url이 같은지 비교
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
몇몇 버그 해결을 위한 변경입니다.

#### 1. TEST_AUTH_DISABLE 옵션 버그
- 현상
  TEST_AUTH_DISABLE 옵션이 적용된 경우 비로그인 상태에도 white list 페이지에 접근가능
- 버그 발생 이유  
  authorize에서 TEST_AUTH_DISABLE가 적용된 경우 인증+인가 체크 전부 스킵함
- 변경  
  TEST_AUTH_DISABLE 옵션이 켜져있어도 인증은 체크하고 인가만 하지 않도록 수정

#### 2. menu_url 체크 이상
- 현상
  메뉴 url 맨 뒤에 /가 붙거나 ?parameter가 적힌 메뉴들은 권한을 부여했음에도 접근없음으로 나옴
- 버그 발생 이유  
  1. 변경된 메뉴 url 체크 로직에서 `/[문자열]/` 인 경우를 정규표현식으로 인식해서 정규표현식 비교를 하려고 했기 때문
  2. 이전 버전에선 ?parameter를 떼고 비교했었는데 그 로직이 삭제되어 다르게 동작
- 변경  
  이전 로직으로 복구