### PR TITLE
Fix authorize error when TEST_ID set

### DIFF
--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -66,6 +66,10 @@ class AdminAuthService
             ]);
         }
 
+        if (!empty($_ENV['TEST_ID'])) {
+            return;
+        }
+
         /** @var AzureOAuth2Service $azure */
         $azure = new AzureOAuth2Service([
             'tenent' => $_ENV['AZURE_TENENT'] ?? '',

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -59,15 +59,35 @@ class AdminAuthService
      */
     public function authorize(string $token, array $methods, string $check_url)
     {
+        if (!empty($_ENV['TEST_ID'])) {
+            $user_id = $_ENV['TEST_ID'];
+        } else {
+            $user_id = self::introspectToken($token);
+        }
+
+        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
+            return;
+        }
+
+        if (!self::checkAuth($methods, $check_url, $user_id)) {
+            throw new UnauthorizedException([
+                'code' => ErrorCode::BAD_REQUEST,
+                'message' => '접근 권한이 없습니다.',
+            ]);
+        }
+    }
+
+    /**
+     * @throws NoTokenException
+     * @throws MalformedTokenException
+     */
+    private function introspectToken($token)
+    {
         if (empty($token)) {
             throw new NoTokenException([
                 'code' => ErrorCode::BAD_REQUEST,
                 'message' => '토큰을 찾을 수 없습니다.',
             ]);
-        }
-
-        if (!empty($_ENV['TEST_ID'])) {
-            return;
         }
 
         /** @var AzureOAuth2Service $azure */
@@ -88,16 +108,7 @@ class AdminAuthService
             ]);
         }
 
-        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
-            return;
-        }
-
-        if (!self::checkAuth($methods, $check_url, $token_resource['user_id'])) {
-            throw new UnauthorizedException([
-                'code' => ErrorCode::BAD_REQUEST,
-                'message' => '접근 권한이 없습니다.',
-            ]);
-        }
+        return  $token_resource['user_id'];
     }
 
     public function checkAuth(array $check_method, string $check_url, string $admin_id): bool

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -90,4 +90,11 @@ class AdminAuthServiceTest extends TestCase
             ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
         ], $result);
     }
+
+    public function testAuthorizeWithTestID()
+    {
+        $_ENV['TEST_ID'] = 'admin';
+        $authService = new AdminAuthService();
+        $this->assertNull($authService->authorize('test', [], '/test'));
+    }
 }

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Ridibooks\Cms\Service;
 
+use Ridibooks\Cms\Thrift\Errors\UnauthorizedException;
 use PHPUnit\Framework\TestCase;
 
 class AdminAuthServiceTest extends TestCase
@@ -91,10 +92,17 @@ class AdminAuthServiceTest extends TestCase
         ], $result);
     }
 
-    public function testAuthorizeWithTestID()
+    public function testAuthorizeSkipTokenValidationWhenTestIDSet()
     {
         $_ENV['TEST_ID'] = 'admin';
-        $authService = new AdminAuthService();
+        $authService = $this->getMockBuilder(AdminAuthService::class)
+            ->setMethods(['checkAuth', 'introspectToken'])
+            ->getMock();
+
+        $authService->expects($this->never())
+            ->method('introspectToken');
+
+        $this->expectException(UnauthorizedException::class);
         $this->assertNull($authService->authorize('test', [], '/test'));
     }
 }


### PR DESCRIPTION
This fixes 500 error during `/authorize` call when `TEST_ID` is set in ENV.