### PR TITLE
If set env TEST_AUTH_DISABLE, set TEST_ID also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Ridibooks CMS
 
 ## [Unreleased]
+### Feature
+- If set env TEST_AUTH_DISABLE, set TEST_ID also
 
 ## [v2.1.7] - 2018-04-16
 ### Fixed

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -59,14 +59,14 @@ class AdminAuthService
      */
     public function authorize(string $token, array $methods, string $check_url)
     {
+        if (!empty($token) && !empty($_ENV['TEST_AUTH_DISABLE'])) {
+            return;
+        }
+
         if (!empty($_ENV['TEST_ID'])) {
             $user_id = $_ENV['TEST_ID'];
         } else {
             $user_id = self::introspectToken($token);
-        }
-
-        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
-            return;
         }
 
         if (!self::checkAuth($methods, $check_url, $user_id)) {

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -18,8 +18,13 @@ class LoginService
 
     const TEST_TOKEN_EXPIRES_SEC = 60 * 60; // 1 hour
 
+    /**
+     * @throws \Exception
+     */
     public static function handleTestLogin(string $return_url, string $test_id): Response
     {
+        self::addUserIfNotExists($test_id, $test_id);
+
         $refresh_expires_on = time() + self::REFRESH_TOKEN_EXPIRES_SEC;
         return self::createLoginResponse(
             $return_url,

--- a/web/index.php
+++ b/web/index.php
@@ -2,12 +2,22 @@
 declare(strict_types=1);
 
 use Ridibooks\Cms\Thrift\ThriftService;
+use Symfony\Component\HttpFoundation\Request;
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
 if (is_readable(__DIR__ . '/../.env')) {
     $dotenv = new Dotenv\Dotenv(__DIR__, '/../.env');
     $dotenv->overload();
+}
+
+// If hostname has a form of dev domain, set test id.
+$request = Request::createFromGlobals();
+if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
+    $hostname = $request->getHost();
+    if (preg_match('/^(cms|admin)\.(\w+)\.dev\.ridi\.io$/', $hostname, $matches)) {
+        $_ENV['TEST_ID'] = $matches[2];
+    }
 }
 
 $cms_rpc_url = $_ENV['CMS_RPC_URL'] ?? '';
@@ -19,4 +29,4 @@ $config = require __DIR__ . '/../config/config.php';
 $app = require __DIR__ . '/../src/app.php';
 require __DIR__ . '/../src/controllers.php';
 
-$app->run();
+$app->run($request);

--- a/web/index.php
+++ b/web/index.php
@@ -15,8 +15,11 @@ if (is_readable(__DIR__ . '/../.env')) {
 $request = Request::createFromGlobals();
 if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
     $hostname = $request->getHost();
-    if (preg_match('/^(cms|admin)\.(\w+)\.dev\.ridi\.io$/', $hostname, $matches)) {
-        $_ENV['TEST_ID'] = $matches[2];
+    $pattern = '/^admin\.(\w+)(\.platform)?\.dev\.ridi\.io$/';
+
+    // 'admin.{test_id}.dev.io' or 'admin.{test_id}.platform.dev.io'
+    if (preg_match($pattern, $hostname, $matches)) {
+        $_ENV['TEST_ID'] = $matches[1];
     }
 }
 


### PR DESCRIPTION
### 배경
기존 개발환경에서 인증과정을 생략하기 위해 `TEST_ID` 환경 변수를 사용했습니다.
각자 서버를 설정했기 때문에 `TEST_ID`를 개인별로 설정이 가능했지만, 이번에 공용 CMS 서버를 사용하면서 개별 설정이 불가능해졌습니다.
`TEST_AUTH_DISABLE`가 켜진 경우, 요청 도메인을 참조해서 로그인 시킬 유저 아이디를 결정하도록 수정했습니다.

### 변경
`TEST_AUTH_DISABLE`가 켜진 경우, request의 host에 따라 환경변수 `TEST_ID`를 설정합니다.  
host가 admin.{id}.dev.ridi.io 형태인 경우에만 `{id}`에 해당하는 값으로 설정합니다.  

Thrift요청을 받을 땐 도메인에 유저 정보가 담겨있지 않아 처리가 어렵습니다.  
`TEST_AUTH_DISABLE`가 켜진 경우 인증, 인가 전부 생략하도록 수정했습니다.   
다만 단순히 전부 무시하면 #51 의 문제가 재발하게 되는데,  token의 유무는 체크하여 버그가 재발하는 것을 방지했습니다 