### PR TITLE
Release v2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Ridibooks CMS
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [v2.1.8] - 2018-04-19
+### Fixed
 - Fix authorize error when TEST_ID set (#53)
 - Support login with test domain when TEST_AUTH_DISABLE is set (#55)
-- Add `authorizeByTag` API support with the update of cms-sdk v2.3.1-rc.1
+
+### Added
+- New `authorizeByTag` API support with the update of cms-sdk v2.3.1-rc.1
 
 ## [v2.1.7] - 2018-04-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v2.1.8] - 2018-04-19
+- Fix authorize error when TEST_ID set (#53)
+- Support login with test domain when TEST_AUTH_DISABLE is set (#55)
+- Add `authorizeByTag` API support with the update of cms-sdk v2.3.1-rc.1
+
 ## [v2.1.7] - 2018-04-16
 ### Fixed
 - Add `/authorize` as white list | cf3efec0


### PR DESCRIPTION
## Summary
This release is for `authorizeByTag` API.
https://app.asana.com/0/314089093619591/615078255787233

## Change List
Fix authorize error when TEST_ID set (#53)
Support login with test domain when TEST_AUTH_DISABLE is set (#55)
Add `authorizeByTag` API support with the update of cms-sdk v2.3.1-rc.1