### PR TITLE
Use auth subdomain

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -11,6 +11,7 @@ $config = [
         'client_secret' => $_ENV['AZURE_CLIENT_SECRET'] ?? '',
         'resource' => $_ENV['AZURE_RESOURCE'] ?? '',
         'redirect_uri' => $_ENV['AZURE_REDIRECT_URI'] ?? '',
+        'redirect_path' => $_ENV['AZURE_REDIRECT_PATH'] ?? '',
         'api_version' => $_ENV['AZURE_API_VERSION'] ?? '',
     ],
     'capsule.connections' => [

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -28,9 +28,11 @@ class AuthController
         ], $response);
     }
 
-    public function logout(Application $app)
+    public function logout(Request $request, Application $app)
     {
-        return LoginService::handleLogout($app['url_generator']->generate('login'));
+        $return_url = $request->get('return_url', $app['url_generator']->generate('login'));
+
+        return LoginService::handleLogout($return_url);
     }
 
     private function buildAuthenticationEndpoint(Application $app)

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -21,12 +21,13 @@ class AzureOAuth2Service
         $this->tenent = $azure_config['tenent'];
         $this->client_id = $azure_config['client_id'];
         $this->client_secret = $azure_config['client_secret'];
-        $this->redirect_uri = $azure_config['redirect_uri'];
         $this->resource = $azure_config['resource'];
         $this->api_version = $azure_config['api_version'];
 
-        if (empty($this->redirect_uri)) {
-             $this->redirect_uri = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $azure_config['redirect_path'];
+        if (!empty($azure_config['redirect_path'])) {
+            $this->redirect_uri = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $azure_config['redirect_path'];
+        } else {
+            $this->redirect_uri = $azure_config['redirect_uri'];
         }
 
         $guzzle_config = array_merge(['verify' => false], $guzzle_config);

--- a/src/Lib/AzureOAuth2Service.php
+++ b/src/Lib/AzureOAuth2Service.php
@@ -25,6 +25,10 @@ class AzureOAuth2Service
         $this->resource = $azure_config['resource'];
         $this->api_version = $azure_config['api_version'];
 
+        if (empty($this->redirect_uri)) {
+             $this->redirect_uri = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $azure_config['redirect_path'];
+        }
+
         $guzzle_config = array_merge(['verify' => false], $guzzle_config);
         $this->http = new Client($guzzle_config);
     }

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -14,7 +14,7 @@ class LoginService
     const REFRESH_COOKIE_NAME = 'cms-refresh';
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
     const REFRESH_TOKEN_EXPIRES_SEC = 60 * 60 * 24 * 30; // 30 days
-    const REFRESH_TOKEN_COOKIE_PATH = '/authorize';
+    const AUTH_SUBDOMAIN = 'auth.';
 
     const TEST_TOKEN_EXPIRES_SEC = 60 * 60; // 1 hour
 
@@ -74,10 +74,12 @@ class LoginService
         int $access_expires_on, string $login_id): Response
     {
         $is_secure = empty($_ENV['TEST_SECURED_DISABLE']) ? true : false;
+        $request_domain = $_SERVER['HTTP_HOST'];
+        $token_domain = str_replace(self::AUTH_SUBDOMAIN, '', $request_domain);
 
-        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', null, $is_secure);
-        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, time() + self::REFRESH_TOKEN_EXPIRES_SEC, self::REFRESH_TOKEN_COOKIE_PATH, null, $is_secure);
-        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', null, $is_secure);
+        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', $token_domain, $is_secure);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, time() + self::REFRESH_TOKEN_EXPIRES_SEC, '/', $request_domain, $is_secure);
+        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', $token_domain, $is_secure);
 
         $response = RedirectResponse::create($return_url);
         $response->headers->setCookie($access_cookie);
@@ -95,10 +97,13 @@ class LoginService
     {
         $is_secure = empty($_ENV['TEST_SECURED_DISABLE']) ? true : false;
 
+        $request_domain = $_SERVER['HTTP_HOST'];
+        $token_domain = str_replace(self::AUTH_SUBDOMAIN, '', $request_domain);
+
         $response = RedirectResponse::create($return_url);
-        $response->headers->clearCookie(self::ADMIN_ID_COOKIE_NAME, '/', null, $is_secure);
-        $response->headers->clearCookie(self::TOKEN_COOKIE_NAME, '/', null, $is_secure);
-        $response->headers->clearCookie(self::REFRESH_COOKIE_NAME, self::REFRESH_TOKEN_COOKIE_PATH, null, $is_secure);
+        $response->headers->clearCookie(self::ADMIN_ID_COOKIE_NAME, '/', $token_domain, $is_secure);
+        $response->headers->clearCookie(self::TOKEN_COOKIE_NAME, '/', $token_domain, $is_secure);
+        $response->headers->clearCookie(self::REFRESH_COOKIE_NAME, '/', $request_domain, $is_secure);
         return $response;
     }
 

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -74,12 +74,12 @@ class LoginService
         int $access_expires_on, string $login_id): Response
     {
         $is_secure = empty($_ENV['TEST_SECURED_DISABLE']) ? true : false;
-        $request_domain = $_SERVER['HTTP_HOST'];
-        $token_domain = str_replace(self::AUTH_SUBDOMAIN, '', $request_domain);
+        $auth_domain = $_SERVER['HTTP_HOST'];
+        $service_domain = str_replace(self::AUTH_SUBDOMAIN, '', $auth_domain);
 
-        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', $token_domain, $is_secure);
-        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, time() + self::REFRESH_TOKEN_EXPIRES_SEC, '/', $request_domain, $is_secure);
-        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', $token_domain, $is_secure);
+        $access_cookie = new Cookie(self::TOKEN_COOKIE_NAME, $access_token, $access_expires_on, '/', $service_domain, $is_secure);
+        $login_id_cookie = new Cookie(self::ADMIN_ID_COOKIE_NAME, $login_id, $access_expires_on, '/', $service_domain, $is_secure);
+        $refresh_cookie = new Cookie(self::REFRESH_COOKIE_NAME, $refresh_token, time() + self::REFRESH_TOKEN_EXPIRES_SEC, '/', $auth_domain, $is_secure);
 
         $response = RedirectResponse::create($return_url);
         $response->headers->setCookie($access_cookie);
@@ -97,13 +97,13 @@ class LoginService
     {
         $is_secure = empty($_ENV['TEST_SECURED_DISABLE']) ? true : false;
 
-        $request_domain = $_SERVER['HTTP_HOST'];
-        $token_domain = str_replace(self::AUTH_SUBDOMAIN, '', $request_domain);
+        $auth_domain = $_SERVER['HTTP_HOST'];
+        $service_domain = str_replace(self::AUTH_SUBDOMAIN, '', $auth_domain);
 
         $response = RedirectResponse::create($return_url);
-        $response->headers->clearCookie(self::ADMIN_ID_COOKIE_NAME, '/', $token_domain, $is_secure);
-        $response->headers->clearCookie(self::TOKEN_COOKIE_NAME, '/', $token_domain, $is_secure);
-        $response->headers->clearCookie(self::REFRESH_COOKIE_NAME, '/', $request_domain, $is_secure);
+        $response->headers->clearCookie(self::ADMIN_ID_COOKIE_NAME, '/', $service_domain, $is_secure);
+        $response->headers->clearCookie(self::TOKEN_COOKIE_NAME, '/', $service_domain, $is_secure);
+        $response->headers->clearCookie(self::REFRESH_COOKIE_NAME, '/', $auth_domain, $is_secure);
         return $response;
     }
 


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/672522917102718/f

1. Set the upper domain for the token cookies.
This is backward compatible since it applies only when the request domain starts with `auth.`

2. Added a new `AZURE_REDIRECT_PATH` ENV value to be able to build Azure redirect URL according to the site domain.
