### PR TITLE
Fix unexpected menu positioning

### DIFF
--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -43,17 +43,28 @@ class AdminAuthService extends Container
 
     public function hideEmptyParentMenus(array $menus): array
     {
-        $topMenuFlags = array_map(function ($menu) {
-            $url = self::parseUrlAuth($menu['menu_url'])['url'];
+        $isParentMenu = function ($menu) {
+            $url = $this->parseUrlAuth($menu['menu_url'])['url'];
 
             return strlen($url) == 0;
-        }, $menus);
+        };
 
-        $topMenuFlags[] = true; // For tail check
-        for ($i = 0; $i < count($menus); ++$i) {
-            if ($topMenuFlags[$i] && $topMenuFlags[$i + 1]) {
-                $menus[$i]['is_show'] = false;
+        for ($i = count($menus) - 1; $i >= 0; $i--) {
+            if (!$isParentMenu($menus[$i])) {
+                continue;
             }
+
+            if (!isset($menus[$i + 1])) {
+                $menus[$i]['is_show'] = false;
+                continue;
+            }
+
+            if ($menus[$i + 1]['menu_deep'] <= $menus[$i]['menu_deep']) {
+                $menus[$i]['is_show'] = false;
+                continue;
+            }
+
+            $menus[$i]['is_show'] = $menus[$i + 1]['is_show'];
         }
 
         return $menus;

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -29,16 +29,27 @@ class AdminAuthService extends Container
             $menus = $this['user_service']->getAllMenus($user_id);
         }
 
+        $menus = $this->removeForbiddenMenus($menus);
         $menus = $this->removeEmptyParentMenus($menus);
 
         $admin_menus = [];
         foreach ($menus as $menu) {
-            if ($menu['is_use'] == 1 && $menu['is_show'] == 1) {
-                $admin_menus[$menu['id']] = $menu;
-            }
+            $admin_menus[$menu['id']] = $menu;
         }
 
         return $admin_menus;
+    }
+
+    public function removeForbiddenMenus(array $menus): array
+    {
+        $nodes = AdminMenuTree::buildTrees($menus);
+        $filtered_nodes = AdminMenuTree::filterTreesPostOrder($nodes, function ($node) {
+            $menu = $node->getMenu();
+            return $menu['is_use'] == 1 && $menu['is_show'] == 1;
+        });
+        $filtered_menus = AdminMenuTree::flattenTrees($filtered_nodes);
+
+        return $filtered_menus;
     }
 
     public function removeEmptyParentMenus(array $menus): array

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -48,6 +48,7 @@ class AdminAuthService extends Container
     {
         return AdminMenuTree::filterTreesPostOrder($menu_trees, function ($node) {
             $menu = $node->getMenu();
+
             return $menu['is_use'] == 1 && $menu['is_show'] == 1;
         });
     }

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -43,13 +43,7 @@ class AdminAuthService extends Container
 
     public function hideEmptyParentMenus(array $menus): array
     {
-        $isParentMenu = function ($menu) {
-            $url = $this->parseUrlAuth($menu['menu_url'])['url'];
-
-            return strlen($url) === 0;
-        };
-
-        $buildMenuTrees = function ($menus) use (&$isParentMenu) {
+        $buildMenuTrees = function ($menus) {
             $root_node = (object)[
                 'menu' => ['menu_deep' => -1, 'menu_url' => '#'],
                 'children' => [],
@@ -72,7 +66,7 @@ class AdminAuthService extends Container
 
                 $parent->children[] = $node;
 
-                if (!$isParentMenu($node->menu)) {
+                if (!AdminMenuService::isParentMenu($node->menu)) {
                     continue;
                 }
 
@@ -100,11 +94,11 @@ class AdminAuthService extends Container
             return $menus;
         };
 
-        $hideEmptyParentMenus = function ($nodes) use (&$hideEmptyParentMenus, &$isParentMenu) {
+        $hideEmptyParentMenus = function ($nodes) use (&$hideEmptyParentMenus) {
             $new_nodes = [];
 
             foreach ($nodes as $node) {
-                if (!$isParentMenu($node->menu)) {
+                if (!AdminMenuService::isParentMenu($node->menu)) {
                     $new_nodes[] = $node;
                     continue;
                 }

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -50,12 +50,12 @@ class AdminAuthService extends Container
         };
 
         $buildMenuTrees = function ($menus) use (&$isParentMenu) {
-            $rootNode = (object)[
+            $root_node = (object)[
                 'menu' => ['menu_deep' => -1, 'menu_url' => '#'],
                 'children' => [],
             ];
 
-            $parentStack = [$rootNode];
+            $parent_stack = [$root_node];
 
             for ($i = 0; $i < count($menus); $i++) {
                 $node = (object)[
@@ -63,11 +63,11 @@ class AdminAuthService extends Container
                     'children' => [],
                 ];
 
-                $parent = (function () use ($parentStack, $node) {
-                    while (end($parentStack)->menu['menu_deep'] >= $node->menu['menu_deep']) {
-                        array_pop($parentStack);
+                $parent = (function () use ($parent_stack, $node) {
+                    while (end($parent_stack)->menu['menu_deep'] >= $node->menu['menu_deep']) {
+                        array_pop($parent_stack);
                     }
-                    return end($parentStack);
+                    return end($parent_stack);
                 })();
 
                 $parent->children[] = $node;
@@ -81,11 +81,11 @@ class AdminAuthService extends Container
                 }
 
                 if ($menus[$i + 1]['menu_deep'] > $node->menu['menu_deep']) {
-                    $parentStack[] = $node;
+                    $parent_stack[] = $node;
                 }
             }
 
-            return $rootNode->children;
+            return $root_node->children;
         };
 
         $flattenMenuTrees = function ($nodes) use (&$flattenMenuTrees) {
@@ -101,35 +101,35 @@ class AdminAuthService extends Container
         };
 
         $hideEmptyParentMenus = function ($nodes) use (&$hideEmptyParentMenus, &$isParentMenu) {
-            $newNodes = [];
+            $new_nodes = [];
 
             foreach ($nodes as $node) {
                 if (!$isParentMenu($node->menu)) {
-                    $newNodes[] = $node;
+                    $new_nodes[] = $node;
                     continue;
                 }
 
-                $isShow = false;
+                $is_show = false;
                 $children = $hideEmptyParentMenus($node->children);
 
                 foreach ($children as $childNode) {
-                    $isShow |= $childNode->menu['is_show'];
+                    $is_show |= $childNode->menu['is_show'];
                 }
 
-                $newNodes[] = (object)[
-                    'menu' => array_merge($node->menu, ['is_show' => $isShow]),
+                $new_nodes[] = (object)[
+                    'menu' => array_merge($node->menu, ['is_show' => $is_show]),
                     'children' => $children,
                 ];
             }
 
-            return $newNodes;
+            return $new_nodes;
         };
 
         $nodes = $buildMenuTrees($menus);
-        $newNodes = $hideEmptyParentMenus($nodes);
-        $newMenus = $flattenMenuTrees($newNodes);
+        $new_nodes = $hideEmptyParentMenus($nodes);
+        $new_menus = $flattenMenuTrees($new_nodes);
 
-        return $newMenus;
+        return $new_menus;
     }
 
     /**

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -29,7 +29,7 @@ class AdminAuthService extends Container
             $menus = $this['user_service']->getAllMenus($user_id);
         }
 
-        $menus = $this->hideEmptyRootMenus($menus);
+        $menus = $this->hideEmptyParentMenus($menus);
 
         $admin_menus = [];
         foreach ($menus as $menu) {
@@ -41,12 +41,12 @@ class AdminAuthService extends Container
         return $admin_menus;
     }
 
-    public function hideEmptyRootMenus(array $menus): array
+    public function hideEmptyParentMenus(array $menus): array
     {
         $topMenuFlags = array_map(function ($menu) {
             $url = self::parseUrlAuth($menu['menu_url'])['url'];
 
-            return $menu['menu_deep'] == 0 && strlen($url) == 0;
+            return strlen($url) == 0;
         }, $menus);
 
         $topMenuFlags[] = true; // For tail check

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -44,7 +44,7 @@ class AdminAuthService extends Container
     public function removeEmptyParentMenus(array $menus): array
     {
         $nodes = AdminMenuTree::buildTrees($menus);
-        $filtered_nodes = AdminMenuTree::filterTrees($nodes, function ($node) {
+        $filtered_nodes = AdminMenuTree::filterTreesPostOrder($nodes, function ($node) {
             $menu = $node->getMenu();
 
             if (AdminMenuService::isParentMenu($menu)) {

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -31,10 +31,10 @@ class AdminMenuService implements AdminMenuServiceIf
         })->all();
     }
 
-    public function getRootMenus($column = null): array
+    public function getParentMenus($column = null): array
     {
         $menus = AdminMenu::query()
-            ->where('menu_deep', 0)
+            ->whereRaw('TRIM(menu_url) = ?', '#')
             ->orderBy('menu_order')
             ->get();
 

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -42,10 +42,8 @@ class AdminMenuService implements AdminMenuServiceIf
     {
         $menus = AdminMenu::query()
             ->orderBy('menu_order')
-            ->get()
-            ->filter(function ($menu) {
-                return AdminMenuService::isParentMenu($menu);
-            });
+            ->whereRaw('TRIM(menu_url) = ?', '#')
+            ->get();
 
         return $menus->map(function ($menu) use ($column) {
             return isset($column) ? $menu->{$column} : $menu->toArray();

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -10,6 +10,12 @@ use Ridibooks\Cms\Thrift\AdminMenu\AdminMenuServiceIf;
 
 class AdminMenuService implements AdminMenuServiceIf
 {
+    public static function isParentMenu($menu): bool {
+        $tokens = preg_split('/#/', $menu['menu_url']);
+
+        return !$tokens[0];
+    }
+
     public function getMenuList($is_use = null): array
     {
         $menus = $this->queryMenus($is_use);
@@ -34,9 +40,11 @@ class AdminMenuService implements AdminMenuServiceIf
     public function getParentMenus($column = null): array
     {
         $menus = AdminMenu::query()
-            ->whereRaw('TRIM(menu_url) = ?', '#')
             ->orderBy('menu_order')
-            ->get();
+            ->get()
+            ->filter(function ($menu) {
+                return AdminMenuService::isParentMenu($menu);
+            });
 
         return $menus->map(function ($menu) use ($column) {
             return isset($column) ? $menu->{$column} : $menu->toArray();

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -10,7 +10,8 @@ use Ridibooks\Cms\Thrift\AdminMenu\AdminMenuServiceIf;
 
 class AdminMenuService implements AdminMenuServiceIf
 {
-    public static function isParentMenu($menu): bool {
+    public static function isParentMenu($menu): bool
+    {
         $tokens = preg_split('/#/', $menu['menu_url']);
 
         return !$tokens[0];

--- a/src/Service/AdminMenuTree.php
+++ b/src/Service/AdminMenuTree.php
@@ -53,11 +53,11 @@ class AdminMenuTree
         return $menus;
     }
 
-    public static function filterTrees(array $trees, callable $match): array {
+    public static function filterTreesPostOrder(array $trees, callable $match): array {
         $filtered_nodes = [];
 
         foreach ($trees as $node) {
-            $filtered_children = AdminMenuTree::filterTrees($node->getChildren(), $match);
+            $filtered_children = AdminMenuTree::filterTreesPostOrder($node->getChildren(), $match);
 
             $node_with_filtered_children = new AdminMenuTree($node->getMenu(), $filtered_children);
 

--- a/src/Service/AdminMenuTree.php
+++ b/src/Service/AdminMenuTree.php
@@ -53,6 +53,22 @@ class AdminMenuTree
         return $menus;
     }
 
+    public static function filterTrees(array $trees, callable $match): array {
+        $filtered_nodes = [];
+
+        foreach ($trees as $node) {
+            $filtered_children = AdminMenuTree::filterTrees($node->getChildren(), $match);
+
+            $node_with_filtered_children = new AdminMenuTree($node->getMenu(), $filtered_children);
+
+            if ($match($node_with_filtered_children)) {
+                $filtered_nodes[] = $node_with_filtered_children;
+            }
+        }
+
+        return $filtered_nodes;
+    }
+
     public function __construct($menu, $children = []) {
         $this->menu = $menu;
         $this->children = array_merge($this->children, $children);

--- a/src/Service/AdminMenuTree.php
+++ b/src/Service/AdminMenuTree.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Service;
+
+class AdminMenuTree
+{
+    private $menu = null;
+    private $children = [];
+
+    public static function buildTrees(array $menus): array {
+        $root_node = new AdminMenuTree(['menu_deep' => -1, 'menu_url' => '#']);
+
+        $parent_stack = [$root_node];
+
+        for ($i = 0; $i < count($menus); $i++) {
+            $node = new AdminMenuTree($menus[$i]);
+
+            $parent = (function () use ($parent_stack, $node) {
+                while (end($parent_stack)->menu['menu_deep'] >= $node->menu['menu_deep']) {
+                    array_pop($parent_stack);
+                }
+                return end($parent_stack);
+            })();
+
+            $parent->children[] = $node;
+
+            if (!AdminMenuService::isParentMenu($node->menu)) {
+                continue;
+            }
+
+            if (!isset($menus[$i + 1])) {
+                break;
+            }
+
+            if ($menus[$i + 1]['menu_deep'] > $node->menu['menu_deep']) {
+                $parent_stack[] = $node;
+            }
+        }
+
+        return $root_node->children;
+    }
+
+    public static function flattenTrees(array $trees): array {
+        $menus = [];
+        foreach ($trees as $node) {
+            $menus = array_merge(
+                $menus,
+                [$node->menu],
+                AdminMenuTree::flattenTrees($node->children)
+            );
+        }
+        return $menus;
+    }
+
+    public function __construct($menu, $children = []) {
+        $this->menu = $menu;
+        $this->children = array_merge($this->children, $children);
+    }
+}

--- a/src/Service/AdminMenuTree.php
+++ b/src/Service/AdminMenuTree.php
@@ -8,18 +8,20 @@ class AdminMenuTree
     private $menu = null;
     private $children = [];
 
-    public static function buildTrees(array $menus): array {
-        $root_node = new AdminMenuTree(['menu_deep' => -1, 'menu_url' => '#']);
+    public static function buildTrees(array $menus): array
+    {
+        $root_node = new self(['menu_deep' => -1, 'menu_url' => '#']);
 
         $parent_stack = [$root_node];
 
-        for ($i = 0; $i < count($menus); $i++) {
-            $node = new AdminMenuTree($menus[$i]);
+        for ($i = 0; $i < count($menus); ++$i) {
+            $node = new self($menus[$i]);
 
             $parent = (function () use ($parent_stack, $node) {
                 while (end($parent_stack)->menu['menu_deep'] >= $node->menu['menu_deep']) {
                     array_pop($parent_stack);
                 }
+
                 return end($parent_stack);
             })();
 
@@ -41,25 +43,28 @@ class AdminMenuTree
         return $root_node->children;
     }
 
-    public static function flattenTrees(array $trees): array {
+    public static function flattenTrees(array $trees): array
+    {
         $menus = [];
         foreach ($trees as $node) {
             $menus = array_merge(
                 $menus,
                 [$node->menu],
-                AdminMenuTree::flattenTrees($node->children)
+                self::flattenTrees($node->children)
             );
         }
+
         return $menus;
     }
 
-    public static function filterTreesPostOrder(array $trees, callable $match): array {
+    public static function filterTreesPostOrder(array $trees, callable $match): array
+    {
         $filtered_nodes = [];
 
         foreach ($trees as $node) {
-            $filtered_children = AdminMenuTree::filterTreesPostOrder($node->getChildren(), $match);
+            $filtered_children = self::filterTreesPostOrder($node->getChildren(), $match);
 
-            $node_with_filtered_children = new AdminMenuTree($node->getMenu(), $filtered_children);
+            $node_with_filtered_children = new self($node->getMenu(), $filtered_children);
 
             if ($match($node_with_filtered_children)) {
                 $filtered_nodes[] = $node_with_filtered_children;
@@ -69,7 +74,8 @@ class AdminMenuTree
         return $filtered_nodes;
     }
 
-    public function __construct($menu, $children = []) {
+    public function __construct($menu, $children = [])
+    {
         $this->menu = $menu;
         $this->children = array_merge($this->children, $children);
     }

--- a/src/Service/AdminMenuTree.php
+++ b/src/Service/AdminMenuTree.php
@@ -57,4 +57,14 @@ class AdminMenuTree
         $this->menu = $menu;
         $this->children = array_merge($this->children, $children);
     }
+
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
 }

--- a/src/Service/AdminUserService.php
+++ b/src/Service/AdminUserService.php
@@ -76,10 +76,10 @@ class AdminUserService implements AdminUserServiceIf
     public function getAllMenus($user_id, $column = null): array
     {
         $menuService = new AdminMenuService();
-        $rootMenus = $menuService->getRootMenus($column);
+        $parent_menus = $menuService->getParentMenus($column);
         $userMenus = $this->selectUserMenus($user_id, $column);
 
-        $menus = array_merge($rootMenus, $userMenus);
+        $menus = array_merge($parent_menus, $userMenus);
         usort($menus, function ($left, $right) {
             $left_order = $left['menu_order'] ?? 0;
             $right_order = $right['menu_order'] ?? 0;

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -88,27 +88,30 @@ class AdminAuthServiceTest extends TestCase
     {
         $auth_service = new AdminAuthService();
 
-        $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => false],
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => false],
-            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+        $menu_trees = [
+            new AdminMenuTree(['id' => 1, 'is_use' => false, 'is_show' => false]),
+            new AdminMenuTree(['id' => 2, 'is_use' => false, 'is_show' => true]),
+            new AdminMenuTree(['id' => 3, 'is_use' => true, 'is_show' => false]),
+            new AdminMenuTree(['id' => 4, 'is_use' => true, 'is_show' => true]),
         ];
-        $result = $auth_service->removeForbiddenMenus($menus);
+        $result = $auth_service->removeForbiddenMenus($menu_trees);
         $this->assertEquals([
-            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+            new AdminMenuTree(['id' => 4, 'is_use' => true, 'is_show' => true]),
         ], $result);
 
-        $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => false],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
+        $menu_trees = [
+            new AdminMenuTree(['id' => 1, 'is_use' => false, 'is_show' => false], [
+                new AdminMenuTree(['id' => 2, 'is_use' => true, 'is_show' => true]),
+            ]),
+            new AdminMenuTree(['id' => 3, 'is_use' => true, 'is_show' => true], [
+                new AdminMenuTree(['id' => 4, 'is_use' => true, 'is_show' => true]),
+            ]),
         ];
-        $result = $auth_service->removeForbiddenMenus($menus);
+        $result = $auth_service->removeForbiddenMenus($menu_trees);
         $this->assertEquals([
-            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
+            new AdminMenuTree(['id' => 3, 'is_use' => true, 'is_show' => true], [
+                new AdminMenuTree(['id' => 4, 'is_use' => true, 'is_show' => true]),
+            ]),
         ], $result);
     }
 
@@ -117,40 +120,48 @@ class AdminAuthServiceTest extends TestCase
         $auth_service = new AdminAuthService();
 
         // Test empty root menus
-        $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/'],
-            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#'],
+        $menu_trees = [
+            new AdminMenuTree(['id' => 1, 'menu_url' => '#']),
+            new AdminMenuTree(['id' => 2, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 3, 'menu_url' => '/']),
+            ]),
+            new AdminMenuTree(['id' => 4, 'menu_url' => '#']),
         ];
-        $result = $auth_service->removeEmptyParentMenus($menus);
+        $result = $auth_service->removeEmptyParentMenus($menu_trees);
         $this->assertEquals([
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/'],
+            new AdminMenuTree(['id' => 2, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 3, 'menu_url' => '/']),
+            ]),
         ], $result);
 
         // Test empty parent menus
-        $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#'],
+        $menu_trees = [
+            new AdminMenuTree(['id' => 1, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 2, 'menu_url' => '#']),
+                new AdminMenuTree(['id' => 3, 'menu_url' => '#'], [
+                    new AdminMenuTree(['id' => 4, 'menu_url' => '#']),
+                ]),
+            ]),
         ];
-        $result = $auth_service->removeEmptyParentMenus($menus);
+        $result = $auth_service->removeEmptyParentMenus($menu_trees);
         $this->assertEquals([], $result);
 
         // Test non-empty parent menus
-        $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/'],
+        $menu_trees = [
+            new AdminMenuTree(['id' => 1, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 2, 'menu_url' => '#']),
+                new AdminMenuTree(['id' => 3, 'menu_url' => '#'], [
+                    new AdminMenuTree(['id' => 4, 'menu_url' => '/']),
+                ]),
+            ]),
         ];
-        $result = $auth_service->removeEmptyParentMenus($menus);
+        $result = $auth_service->removeEmptyParentMenus($menu_trees);
         $this->assertEquals([
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/'],
+            new AdminMenuTree(['id' => 1, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 3, 'menu_url' => '#'], [
+                    new AdminMenuTree(['id' => 4, 'menu_url' => '/']),
+                ]),
+            ]),
         ], $result);
     }
 

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -84,7 +84,7 @@ class AdminAuthServiceTest extends TestCase
         $this->assertEquals(['EDIT_세트도서'], $hashs);
     }
 
-    public function testHideEmptyRootMenus()
+    public function testHideEmptyParentMenus()
     {
         $menus = [
             ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
@@ -94,7 +94,7 @@ class AdminAuthServiceTest extends TestCase
         ];
 
         $auth_service = new AdminAuthService();
-        $result = $auth_service->hideEmptyRootMenus($menus);
+        $result = $auth_service->hideEmptyParentMenus($menus);
         $this->assertEquals([
             ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
             ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -84,6 +84,34 @@ class AdminAuthServiceTest extends TestCase
         $this->assertEquals(['EDIT_세트도서'], $hashs);
     }
 
+    public function testRemoveForbiddenMenus()
+    {
+        $auth_service = new AdminAuthService();
+
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => false],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => false],
+            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+        ];
+        $result = $auth_service->removeForbiddenMenus($menus);
+        $this->assertEquals([
+            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+        ], $result);
+
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => false, 'is_show' => false],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
+        ];
+        $result = $auth_service->removeForbiddenMenus($menus);
+        $this->assertEquals([
+            ['id' => 3, 'menu_deep' => 0, 'menu_url' => '#', 'is_use' => true, 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '/', 'is_use' => true, 'is_show' => true],
+        ], $result);
+    }
+
     public function testRemoveEmptyParentMenus()
     {
         $auth_service = new AdminAuthService();

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -86,20 +86,47 @@ class AdminAuthServiceTest extends TestCase
 
     public function testHideEmptyParentMenus()
     {
-        $menus = [
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-        ];
-
         $auth_service = new AdminAuthService();
+
+        // Test empty root menus
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+        ];
         $result = $auth_service->hideEmptyParentMenus($menus);
         $this->assertEquals([
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
-            ['menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
+        ], $result);
+
+        // Test empty parent menus
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => true],
+        ];
+        $result = $auth_service->hideEmptyParentMenus($menus);
+        $this->assertEquals([
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => false],
+        ], $result);
+
+        // Test non-empty parent menus
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
+        ];
+        $result = $auth_service->hideEmptyParentMenus($menus);
+        $this->assertEquals([
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
         ], $result);
     }
 

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -84,7 +84,7 @@ class AdminAuthServiceTest extends TestCase
         $this->assertEquals(['EDIT_세트도서'], $hashs);
     }
 
-    public function testHideEmptyParentMenus()
+    public function testRemoveEmptyParentMenus()
     {
         $auth_service = new AdminAuthService();
 
@@ -95,12 +95,10 @@ class AdminAuthServiceTest extends TestCase
             ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
             ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
         ];
-        $result = $auth_service->hideEmptyParentMenus($menus);
+        $result = $auth_service->removeEmptyParentMenus($menus);
         $this->assertEquals([
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
             ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
             ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
         ], $result);
 
         // Test empty parent menus
@@ -110,13 +108,8 @@ class AdminAuthServiceTest extends TestCase
             ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
             ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => true],
         ];
-        $result = $auth_service->hideEmptyParentMenus($menus);
-        $this->assertEquals([
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => false],
-        ], $result);
+        $result = $auth_service->removeEmptyParentMenus($menus);
+        $this->assertEquals([], $result);
 
         // Test non-empty parent menus
         $menus = [
@@ -125,10 +118,9 @@ class AdminAuthServiceTest extends TestCase
             ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
             ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
         ];
-        $result = $auth_service->hideEmptyParentMenus($menus);
+        $result = $auth_service->removeEmptyParentMenus($menus);
         $this->assertEquals([
             ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
             ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
             ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
         ], $result);

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -118,39 +118,39 @@ class AdminAuthServiceTest extends TestCase
 
         // Test empty root menus
         $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/'],
+            ['id' => 4, 'menu_deep' => 0, 'menu_url' => '#'],
         ];
         $result = $auth_service->removeEmptyParentMenus($menus);
         $this->assertEquals([
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '/'],
         ], $result);
 
         // Test empty parent menus
         $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#'],
         ];
         $result = $auth_service->removeEmptyParentMenus($menus);
         $this->assertEquals([], $result);
 
         // Test non-empty parent menus
         $menus = [
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/'],
         ];
         $result = $auth_service->removeEmptyParentMenus($menus);
         $this->assertEquals([
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/'],
         ], $result);
     }
 

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -107,26 +107,30 @@ class AdminAuthServiceTest extends TestCase
         $menus = [
             ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
             ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => true],
         ];
         $result = $auth_service->hideEmptyParentMenus($menus);
         $this->assertEquals([
             ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => false],
             ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
-            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '#', 'is_show' => false],
         ], $result);
 
         // Test non-empty parent menus
         $menus = [
             ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
             ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
         ];
         $result = $auth_service->hideEmptyParentMenus($menus);
         $this->assertEquals([
             ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
-            ['id' => 3, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
+            ['id' => 2, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => false],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#', 'is_show' => true],
+            ['id' => 4, 'menu_deep' => 2, 'menu_url' => '/', 'is_show' => true],
         ], $result);
     }
 

--- a/tests/AdminMenuTreeTest.php
+++ b/tests/AdminMenuTreeTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+use Ridibooks\Cms\Service\AdminMenuTree;
+use PHPUnit\Framework\TestCase;
+
+class AdminMenuTreeTest extends TestCase
+{
+    public function testBuildTrees()
+    {
+        $menus = [
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 5, 'menu_deep' => 2, 'menu_url' => '#'],
+            ['id' => 6, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 7, 'menu_deep' => 0, 'menu_url' => '#'],
+        ];
+        $trees = AdminMenuTree::buildTrees($menus);
+        $this->assertEquals([
+            new AdminMenuTree(['id' => 1, 'menu_deep' => 0, 'menu_url' => '#']),
+            new AdminMenuTree(['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 3, 'menu_deep' => 1, 'menu_url' => '#']),
+                new AdminMenuTree(['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'], [
+                    new AdminMenuTree(['id' => 5, 'menu_deep' => 2, 'menu_url' => '#']),
+                ]),
+                new AdminMenuTree(['id' => 6, 'menu_deep' => 1, 'menu_url' => '#']),
+            ]),
+            new AdminMenuTree(['id' => 7, 'menu_deep' => 0, 'menu_url' => '#']),
+        ], $trees);
+    }
+
+    public function testFlattenTrees()
+    {
+        $trees = [
+            new AdminMenuTree(['id' => 1, 'menu_deep' => 0, 'menu_url' => '#']),
+            new AdminMenuTree(['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'], [
+                new AdminMenuTree(['id' => 3, 'menu_deep' => 1, 'menu_url' => '#']),
+                new AdminMenuTree(['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'], [
+                    new AdminMenuTree(['id' => 5, 'menu_deep' => 2, 'menu_url' => '#']),
+                ]),
+                new AdminMenuTree(['id' => 6, 'menu_deep' => 1, 'menu_url' => '#']),
+            ]),
+            new AdminMenuTree(['id' => 7, 'menu_deep' => 0, 'menu_url' => '#']),
+        ];
+        $menus = AdminMenuTree::flattenTrees($trees);
+        $this->assertEquals([
+            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 5, 'menu_deep' => 2, 'menu_url' => '#'],
+            ['id' => 6, 'menu_deep' => 1, 'menu_url' => '#'],
+            ['id' => 7, 'menu_deep' => 0, 'menu_url' => '#'],
+        ], $menus);
+    }
+}

--- a/tests/AdminMenuTreeTest.php
+++ b/tests/AdminMenuTreeTest.php
@@ -34,25 +34,25 @@ class AdminMenuTreeTest extends TestCase
     public function testFlattenTrees()
     {
         $trees = [
-            new AdminMenuTree(['id' => 1, 'menu_deep' => 0, 'menu_url' => '#']),
-            new AdminMenuTree(['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'], [
-                new AdminMenuTree(['id' => 3, 'menu_deep' => 1, 'menu_url' => '#']),
-                new AdminMenuTree(['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'], [
-                    new AdminMenuTree(['id' => 5, 'menu_deep' => 2, 'menu_url' => '#']),
+            new AdminMenuTree(['id' => 1]),
+            new AdminMenuTree(['id' => 2], [
+                new AdminMenuTree(['id' => 3]),
+                new AdminMenuTree(['id' => 4], [
+                    new AdminMenuTree(['id' => 5]),
                 ]),
-                new AdminMenuTree(['id' => 6, 'menu_deep' => 1, 'menu_url' => '#']),
+                new AdminMenuTree(['id' => 6]),
             ]),
-            new AdminMenuTree(['id' => 7, 'menu_deep' => 0, 'menu_url' => '#']),
+            new AdminMenuTree(['id' => 7]),
         ];
         $menus = AdminMenuTree::flattenTrees($trees);
         $this->assertEquals([
-            ['id' => 1, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 2, 'menu_deep' => 0, 'menu_url' => '#'],
-            ['id' => 3, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 4, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 5, 'menu_deep' => 2, 'menu_url' => '#'],
-            ['id' => 6, 'menu_deep' => 1, 'menu_url' => '#'],
-            ['id' => 7, 'menu_deep' => 0, 'menu_url' => '#'],
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+            ['id' => 4],
+            ['id' => 5],
+            ['id' => 6],
+            ['id' => 7],
         ], $menus);
     }
 

--- a/tests/AdminMenuTreeTest.php
+++ b/tests/AdminMenuTreeTest.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Ridibooks\Cms\Service\AdminMenuTree;
 use PHPUnit\Framework\TestCase;
+use Ridibooks\Cms\Service\AdminMenuTree;
 
 class AdminMenuTreeTest extends TestCase
 {
@@ -56,7 +56,8 @@ class AdminMenuTreeTest extends TestCase
         ], $menus);
     }
 
-    public function testFilterTreesPostOrder() {
+    public function testFilterTreesPostOrder()
+    {
         $trees = [
             new AdminMenuTree(['id' => 1, 'is_show' => true]),
             new AdminMenuTree(['id' => 2, 'is_show' => false]),

--- a/tests/AdminMenuTreeTest.php
+++ b/tests/AdminMenuTreeTest.php
@@ -56,7 +56,7 @@ class AdminMenuTreeTest extends TestCase
         ], $menus);
     }
 
-    public function testFilterTrees() {
+    public function testFilterTreesPostOrder() {
         $trees = [
             new AdminMenuTree(['id' => 1, 'is_show' => true]),
             new AdminMenuTree(['id' => 2, 'is_show' => false]),
@@ -64,7 +64,7 @@ class AdminMenuTreeTest extends TestCase
             new AdminMenuTree(['id' => 4, 'is_show' => false]),
             new AdminMenuTree(['id' => 5, 'is_show' => true]),
         ];
-        $filtered_trees = AdminMenuTree::filterTrees($trees, function ($node) {
+        $filtered_trees = AdminMenuTree::filterTreesPostOrder($trees, function ($node) {
             return $node->getMenu()['is_show'];
         });
         $this->assertEquals([
@@ -86,7 +86,7 @@ class AdminMenuTreeTest extends TestCase
                 ]),
             ]),
         ];
-        $filtered_trees = AdminMenuTree::filterTrees($trees, function ($node) {
+        $filtered_trees = AdminMenuTree::filterTreesPostOrder($trees, function ($node) {
             $menu = $node->getMenu();
 
             if ($menu['menu_url'] === '#') {


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/678316075713797/f

When requesting menus for the menu UI, the result has contained only exact menus that are permitted to the current user without associated parent menus. As a result, **menus are positioned to unexpected parents' children**.

This PR will fix the problem by **exposing associated parent menus without the permission**.
- The menus have url of `#` will be regarded as potential parent menus.