### PR TITLE
Fix CMS UI menu scrolling bug

### DIFF
--- a/views/base.twig
+++ b/views/base.twig
@@ -67,7 +67,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/@ridi/cms-ui@0.3.1/dist/cms-ui.var.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@ridi/cms-ui@^0.3/dist/cms-ui.var.js"></script>
     <script type="text/javascript" src="{{ BOWER_PATH }}/requirejs/require.js"></script>
     <script>
       requirejs.config({


### PR DESCRIPTION
이슈: https://app.asana.com/0/0/688275289313548/f

Firefox 브라우저에서 CMS UI의 메뉴가 스크롤되지 않는 버그가 있었습니다. [Firefox의 flexbox에 관련된 문제](https://stackoverflow.com/questions/44948158/flexbox-overflow-issue-in-firefox)로 해당 버그는 [CMS UI에서 수정](https://github.com/ridi/cms-ui/commit/0fd4c60fde9d4d2ab37e84d756a7ad6ee3fcd812)되었고, 향후 버그수정의 빠른 적용을 위해 CMS UI의 참조 버전을 특정 버전(0.3.1)에서 0.3.x로 변경했습니다.

감사합니다.