### PR TITLE
Add user group for tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.php_cs.cache
 vendor
 web/static/bower_components
 !tests/.env

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -13,5 +13,6 @@ else
     mysql -h${PHINX_DBHOST} -u${PHINX_DBUSER} -p${PHINX_DBPASS} -e "CREATE DATABASE IF NOT EXISTS ${PHINX_DBNAME};"
 fi
 
+vendor/bin/phinx rollback -t 0 -e phinx_env
 vendor/bin/phinx migrate -e phinx_env
-vendor/bin/phinx seed:run -s User -s Menu -s MenuAjax -s Tag -s TagMenu -s UserTag -e phinx_env
+vendor/bin/phinx seed:run -s User -s Menu -s MenuAjax -s Tag -s TagMenu -s UserTag -s Group -s GroupTag -s GroupUser -e phinx_env

--- a/phinx/migrations/20170810100141_init_cms.php
+++ b/phinx/migrations/20170810100141_init_cms.php
@@ -26,7 +26,7 @@ class InitCms extends AbstractMigration
             ->addColumn('team', 'string', ['length' => 32])
             ->addColumn('is_use', 'boolean')
             ->addColumn('reg_date', 'timestamp')
-            ->addColumn('azure_id', 'string', ['length' => 32])
+            ->addColumn('azure_id', 'string', ['length' => 32, 'default' => ''])
             ->create();
     }
 

--- a/phinx/migrations/20180502030243_add_tag_display_name_column.php
+++ b/phinx/migrations/20180502030243_add_tag_display_name_column.php
@@ -1,0 +1,14 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddTagDisplayNameColumn extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('tb_admin2_tag')
+            ->addColumn('display_name', 'string', ['length' => 32, 'after' => 'name'])
+            ->addIndex(['name'], [ 'unique' => true ])
+            ->update();
+    }
+}

--- a/phinx/migrations/20180523061119_add_group.php
+++ b/phinx/migrations/20180523061119_add_group.php
@@ -19,7 +19,6 @@ class AddGroup extends AbstractMigration
             ->addColumn('user_id', 'string', ['length' => 32])
             ->addForeignKey('group_id', 'tb_admin2_group', 'id') 
             ->addForeignKey('user_id', 'tb_admin2_user', 'id') 
-            ->addIndex('user_id')
             ->create();
 
         $this->table('tb_admin2_group_tag')
@@ -27,7 +26,6 @@ class AddGroup extends AbstractMigration
             ->addColumn('tag_id', 'integer')
             ->addForeignKey('group_id', 'tb_admin2_group', 'id') 
             ->addForeignKey('tag_id', 'tb_admin2_tag', 'id') 
-            ->addIndex('tag_id')
             ->create();
     }
 }

--- a/phinx/migrations/20180523061119_add_group.php
+++ b/phinx/migrations/20180523061119_add_group.php
@@ -10,7 +10,7 @@ class AddGroup extends AbstractMigration
             ->addColumn('name', 'string', ['length' => 32])
             ->addColumn('is_use', 'boolean')
             ->addColumn('creator', 'string', ['length' => 32])
-            ->addIndex('name')
+            ->addIndex('name', [ 'unique' => true ])
             ->addTimestamps()
             ->create();
 

--- a/phinx/migrations/20180523061119_add_group.php
+++ b/phinx/migrations/20180523061119_add_group.php
@@ -1,0 +1,33 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddGroup extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('tb_admin2_group')
+            ->addColumn('name', 'string', ['length' => 32])
+            ->addColumn('is_use', 'boolean')
+            ->addColumn('creator', 'string', ['length' => 32])
+            ->addIndex('name')
+            ->addTimestamps()
+            ->create();
+
+        $this->table('tb_admin2_group_user')
+            ->addColumn('group_id', 'integer')
+            ->addColumn('user_id', 'string', ['length' => 32])
+            ->addForeignKey('group_id', 'tb_admin2_group', 'id') 
+            ->addForeignKey('user_id', 'tb_admin2_user', 'id') 
+            ->addIndex('user_id')
+            ->create();
+
+        $this->table('tb_admin2_group_tag')
+            ->addColumn('group_id', 'integer')
+            ->addColumn('tag_id', 'integer')
+            ->addForeignKey('group_id', 'tb_admin2_group', 'id') 
+            ->addForeignKey('tag_id', 'tb_admin2_tag', 'id') 
+            ->addIndex('tag_id')
+            ->create();
+    }
+}

--- a/phinx/migrations/20180524084101_add_group_view.php
+++ b/phinx/migrations/20180524084101_add_group_view.php
@@ -1,0 +1,25 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddGroupView extends AbstractMigration
+{
+    private $VIEW_NAME = 'vw_admin2_user_tag_via_group';
+
+    public function up()
+    {
+        $this->execute("create view {$this->VIEW_NAME} AS
+            select user_id, tag_id
+            from tb_admin2_user_tag
+            union
+            select group_user.user_id, group_tag.tag_id
+            from tb_admin2_group_tag as group_tag
+            join tb_admin2_group_user as group_user on group_user.group_id = group_tag.group_id;
+        ");
+    }
+
+    public function down()
+    {
+        $this->execute("drop view {$this->VIEW_NAME}");
+    }
+}

--- a/phinx/migrations/20180524084101_add_group_view.php
+++ b/phinx/migrations/20180524084101_add_group_view.php
@@ -4,7 +4,7 @@ use Phinx\Migration\AbstractMigration;
 
 class AddGroupView extends AbstractMigration
 {
-    private $VIEW_NAME = 'vw_admin2_user_tag_group_joined';
+    private $VIEW_NAME = 'v_admin2_user_tag_group_joined';
 
     public function up()
     {

--- a/phinx/migrations/20180524084101_add_group_view.php
+++ b/phinx/migrations/20180524084101_add_group_view.php
@@ -4,7 +4,7 @@ use Phinx\Migration\AbstractMigration;
 
 class AddGroupView extends AbstractMigration
 {
-    private $VIEW_NAME = 'vw_admin2_user_tag_via_group';
+    private $VIEW_NAME = 'vw_admin2_user_tag_group_joined';
 
     public function up()
     {

--- a/phinx/seeds/Group.php
+++ b/phinx/seeds/Group.php
@@ -1,0 +1,21 @@
+<?php 
+declare(strict_types=1); 
+ 
+use Phinx\Seed\AbstractSeed; 
+ 
+class Group extends AbstractSeed 
+{ 
+    public function run() 
+    { 
+        $data = [ 
+            [ 
+                'name' => 'my_team', 
+                'is_use' => 1, 
+                'creator' => 'admin', 
+            ], 
+        ]; 
+ 
+        $posts = $this->table('tb_admin2_group'); 
+        $posts->insert($data)->save(); 
+    } 
+} 

--- a/phinx/seeds/GroupTag.php
+++ b/phinx/seeds/GroupTag.php
@@ -1,0 +1,20 @@
+<?php 
+declare(strict_types=1); 
+ 
+use Phinx\Seed\AbstractSeed; 
+ 
+class GroupTag extends AbstractSeed 
+{ 
+    public function run() 
+    { 
+        $data = [ 
+            [ 
+                'group_id' => 1, 
+                'tag_id' => 2, 
+            ], 
+        ]; 
+ 
+        $posts = $this->table('tb_admin2_group_tag'); 
+        $posts->insert($data)->save(); 
+    } 
+} 

--- a/phinx/seeds/GroupUser.php
+++ b/phinx/seeds/GroupUser.php
@@ -1,0 +1,20 @@
+<?php 
+declare(strict_types=1); 
+ 
+use Phinx\Seed\AbstractSeed; 
+ 
+class GroupUser extends AbstractSeed 
+{ 
+    public function run() 
+    { 
+        $data = [ 
+            [ 
+                'user_id' => 'admin', 
+                'group_id' => 1, 
+            ], 
+        ]; 
+ 
+        $posts = $this->table('tb_admin2_group_user'); 
+        $posts->insert($data)->save(); 
+    } 
+} 

--- a/phinx/seeds/Tag.php
+++ b/phinx/seeds/Tag.php
@@ -10,18 +10,21 @@ class Tag extends AbstractSeed
         $data = [
             [
                 'name' => '권한 관리',
+                'display_name' => '권한 관리',
                 'is_use' => 1,
                 'creator' => 'admin',
                 'reg_date' => date('Y-m-d H:i:s'),
             ],
             [
                 'name' => '테스트',
+                'display_name' => '테스트',
                 'is_use' => 1,
                 'creator' => 'admin',
                 'reg_date' => date('Y-m-d H:i:s'),
             ],
             [
                 'name' => '안쓰는 태그',
+                'display_name' => '안쓰는 태그',
                 'is_use' => 0,
                 'creator' => 'admin',
                 'reg_date' => date('Y-m-d H:i:s'),

--- a/src/Model/AdminGroup.php
+++ b/src/Model/AdminGroup.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Model;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AdminGroup extends Model
+{
+    protected $table = 'tb_admin2_group';
+
+    protected $fillable = [
+        'id',
+        'name',
+        'is_use',
+        'creator'
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(
+            AdminUser::class,
+            'tb_admin2_group_user',
+            'group_id',
+            'user_id'
+        );
+    }
+}

--- a/src/Model/AdminTag.php
+++ b/src/Model/AdminTag.php
@@ -31,6 +31,16 @@ class AdminTag extends Model
         );
     }
 
+    public function groups()
+    {
+        return $this->belongsToMany(
+            AdminGroup::class,
+            'tb_admin2_group_tag',
+            'tag_id',
+            'group_id'
+        );
+    }
+
     public function menus()
     {
         return $this->belongsToMany(

--- a/src/Model/AdminUser.php
+++ b/src/Model/AdminUser.php
@@ -33,6 +33,26 @@ class AdminUser extends Model
         );
     }
 
+    public function tags_group_joined()
+    {
+        return $this->belongsToMany(
+            AdminTag::class,
+            'vw_admin2_user_tag_group_joined',
+            'user_id',
+            'tag_id'
+        );
+    }
+
+    public function groups()
+    {
+        return $this->belongsToMany(
+            AdminGroup::class,
+            'tb_admin2_group_user',
+            'user_id',
+            'group_id'
+        );
+    }
+
     public function menus()
     {
         return $this->belongsToMany(

--- a/src/Model/AdminUser.php
+++ b/src/Model/AdminUser.php
@@ -37,7 +37,7 @@ class AdminUser extends Model
     {
         return $this->belongsToMany(
             AdminTag::class,
-            'vw_admin2_user_tag_group_joined',
+            'v_admin2_user_tag_group_joined',
             'user_id',
             'tag_id'
         );

--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -172,7 +172,7 @@ class AdminAuthService extends Container
             return false;
         }
 
-        $user_tags = $this['user_service']->getAdminUserTag($admin_id);
+        $user_tags = $this['user_service']->getAdminUserAllTag($admin_id);
         $required_tags = $this['tag_service']->findTagsByName($tag_names);
 
         if (!empty(array_intersect($user_tags, $required_tags))) {

--- a/src/Service/AdminUserService.php
+++ b/src/Service/AdminUserService.php
@@ -44,6 +44,17 @@ class AdminUserService implements AdminUserServiceIf
         return $user->tags->pluck('id')->all();
     }
 
+    public function getAdminUserAllTag($user_id): array
+    {
+        /** @var AdminUser $user */
+        $user = AdminUser::find($user_id);
+        if (!$user) {
+            return [];
+        }
+
+        return $user->tags_group_joined->pluck('id')->all();
+    }
+
     public function getAdminUserMenu($user_id, $column = 'id'): array
     {
         /** @var AdminUser $user */

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -121,7 +121,7 @@ class AdminAuthServiceTest extends TestCase
     {
         $this->auth_service['user_service']->method('getUser')
             ->willReturn(new AdminUser(['id' => 'test', 'is_use' => true]));
-        $this->auth_service['user_service']->method('getAdminUserTag')
+        $this->auth_service['user_service']->method('getAdminUserAllTag')
             ->willReturn([1, 2]);
         $this->auth_service['tag_service']->method('findTagsByName')
             ->will($this->onConsecutiveCalls(
@@ -136,7 +136,7 @@ class AdminAuthServiceTest extends TestCase
         $this->auth_service->authorizeByTag('test', ['test']);
     }
 
-    public function testAuthorizeFailIfUserIsInvalid()
+    public function testAuthorizeFailWithInvalidUser()
     {
         $this->auth_service['user_service']->method('getUser')
             ->willReturn(new AdminUser(['id' => 'test', 'is_use' => false]));

--- a/tests/AdminGroupModelTest.php
+++ b/tests/AdminGroupModelTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Model;
+
+use PHPUnit\Framework\TestCase;
+
+class GroupModelTest extends TestCase
+{
+    public function testGetGroups()
+    {
+        $groups = AdminGroup::find(1)->pluck('name')->all();
+
+        $this->assertEquals(['my_team'], $groups);
+    }
+
+    public function testGetUsersFromGroup()
+    {
+        $users = AdminGroup::find(1)->users->pluck('name')->all();
+
+        $this->assertEquals(['관리자'], $users);
+    }
+
+    public function testGetGroupsFromTag()
+    {
+        $groups = AdminTag::find(2)->groups->pluck('name')->all();
+
+        $this->assertEquals(['my_team'], $groups);
+    }
+
+    public function testGetGroupsFromUser()
+    {
+        $groups = AdminUser::find('admin')->groups->pluck('name')->all();
+
+        $this->assertEquals(['my_team'], $groups);
+    }
+
+    public function testGetTagViaGroup()
+    {
+        $direct_tags = AdminUser::find('admin')->tags->pluck('name')->all();
+        $tags = AdminUser::find('admin')->tags_group_joined->pluck('name')->all();
+
+        $this->assertEquals(['권한 관리'], $direct_tags);
+        $this->assertEquals(['권한 관리', '테스트'], $tags);
+    }
+}

--- a/tests/AdminUserServiceTest.php
+++ b/tests/AdminUserServiceTest.php
@@ -28,4 +28,11 @@ class AdminUserServiceTest extends TestCase
         $ajax_list = $user_service->getAllMenuAjaxList('admin', 'ajax_url');
         $this->assertNotEmpty($ajax_list);
     }
+
+    public function testGetAdminUserAllTagIncludesTagsFromUserGroup()
+    {
+        $user_service = new AdminUserService();
+        $this->assertEquals([1], $user_service->getAdminUserTag('admin'));
+        $this->assertEquals([1, 2], $user_service->getAdminUserAllTag('admin'));
+    }
 }


### PR DESCRIPTION
This PR introduces user group.
https://app.asana.com/0/314089093619591/665707044394720

## Changes
- Added new `tb_admin2_group` table. (and many to many relationship tables)
- Added a view `vw_admin2_user_tag_group_joined` which is a union view of `tb_admin2_user_tag` and `tb_admin2_group_tag`.
  - This is for a better readability and simplicity of the codebase.
  - Any other name suggestion is welcome :)
- `authorizeByTag` API now searches `vw_admin2_user_tag_group_joined` view to include tags in groups.


CMS-Admin as well will add the user group feature for CRUD operations. 