### PR TITLE
User menus includes tags over groups

### DIFF
--- a/phinx/seeds/Menu.php
+++ b/phinx/seeds/Menu.php
@@ -68,6 +68,16 @@ class Menu extends AbstractSeed
                 'is_newtab' => 0,
                 'reg_date' => date('Y-m-d H:i:s'),
             ],
+            [
+                'menu_title' => 'Group 테스트',
+                'menu_url' => '/super/users#GROUP',
+                'menu_order' => 5,
+                'menu_deep' => 0,
+                'is_use' => 1,
+                'is_show' => 0,
+                'is_newtab' => 0,
+                'reg_date' => date('Y-m-d H:i:s'),
+            ],
         ];
 
         $posts = $this->table('tb_admin2_menu');

--- a/phinx/seeds/TagMenu.php
+++ b/phinx/seeds/TagMenu.php
@@ -28,6 +28,10 @@ class TagMenu extends AbstractSeed
                 'tag_id' => 1,
                 'menu_id' => 6,
             ],
+            [
+                'tag_id' => 2,
+                'menu_id' => 7,
+            ],
         ];
 
         $posts = $this->table('tb_admin2_tag_menu');

--- a/src/Service/AdminUserService.php
+++ b/src/Service/AdminUserService.php
@@ -160,8 +160,8 @@ class AdminUserService implements AdminUserServiceIf
         $user_tag_menus = DB::select('select tb_admin2_menu.*
             from tb_admin2_menu
             join tb_admin2_tag_menu on tb_admin2_tag_menu.menu_id = tb_admin2_menu.id
-            join tb_admin2_user_tag on tb_admin2_user_tag.tag_id = tb_admin2_tag_menu.tag_id
-            where tb_admin2_user_tag.user_id = :user', ['user' => $user]);
+            join v_admin2_user_tag_group_joined on v_admin2_user_tag_group_joined.tag_id = tb_admin2_tag_menu.tag_id
+            where v_admin2_user_tag_group_joined.user_id = :user', ['user' => $user]);
 
         // menu -> user
         $user_menus = DB::select('select tb_admin2_menu.*
@@ -184,8 +184,8 @@ class AdminUserService implements AdminUserServiceIf
             from tb_admin2_menu_ajax
             join tb_admin2_menu on tb_admin2_menu_ajax.menu_id = tb_admin2_menu.id
             join tb_admin2_tag_menu on tb_admin2_tag_menu.menu_id = tb_admin2_menu.id
-            join tb_admin2_user_tag on tb_admin2_user_tag.tag_id = tb_admin2_tag_menu.tag_id
-            where tb_admin2_user_tag.user_id = :user', ['user' => $user]);
+            join v_admin2_user_tag_group_joined on v_admin2_user_tag_group_joined.tag_id = tb_admin2_tag_menu.tag_id
+            where v_admin2_user_tag_group_joined.user_id = :user', ['user' => $user]);
 
         // ajax -> menu -> user
         $user_menu_ajax_list = DB::select('select *

--- a/tests/AdminUserServiceTest.php
+++ b/tests/AdminUserServiceTest.php
@@ -22,6 +22,13 @@ class AdminUserServiceTest extends TestCase
         $this->assertNotEmpty($menus);
     }
 
+    public function testGetAllMenusIncludesTagsOverGroup()
+    {
+        $user_service = new AdminUserService();
+        $menus = $user_service->getAllMenus('admin', 'menu_title');
+        $this->assertContains('Group 테스트', $menus);
+    }
+
     public function testGetAllMenuAjaxList()
     {
         $user_service = new AdminUserService();


### PR DESCRIPTION
This is a follow-up PR of #68.

## Changes
Fix the left menu list to include menus over groups.