### PR TITLE
WIP: Fix wrong OAuth2 authorize

### DIFF
--- a/src/Service/Auth/AuthenticationServiceProvider.php
+++ b/src/Service/Auth/AuthenticationServiceProvider.php
@@ -73,7 +73,7 @@ class AuthenticationServiceProvider implements ServiceProviderInterface, Bootabl
         $app['auth.cookie.oauth2'] = [
             OAuth2Authenticator::KEY_PROVIDER => [
                 'key' => 'oauth2_provider',
-                'lifetime' => 60 * 60 * 2, // 2 hours,
+                'lifetime' => 60 * 60 * 24 * 30, // 30 days,
             ],
             OAuth2Authenticator::KEY_ACCESS_TOKEN => [
                 'key' => 'cms-token',

--- a/src/Service/Auth/OAuth2/Client/AzureClient.php
+++ b/src/Service/Auth/OAuth2/Client/AzureClient.php
@@ -71,7 +71,7 @@ class AzureClient implements OAuth2ClientInterface
 
         // For some users, azure ID and azure email is differnt. So, request mailNickname explicitly rather than parse id from email.
         // See https://app.asana.com/0/314089093619591/726274713560091
-        $token_object = new AccessToken(['access_token' => $access_token, 'expires' => $token_claims['exp'] ], $this->azure);
+        $token_object = new AccessToken(['access_token' => $access_token, 'expires' => $token_claims['exp']], $this->azure);
         $user = $this->azure->get('me?api-version=2013-11-08', $token_object);
 
         return $user['mailNickname'];

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -5,7 +5,7 @@ use Ridibooks\Cms\Controller;
 use Ridibooks\Cms\Service\Auth\AuthMiddleware;
 use Silex\ControllerCollection;
 
-// Login service
+// Auth service
 /** @var ControllerCollection $auth_controller */
 $auth_controller = $app['controllers_factory'];
 
@@ -17,16 +17,15 @@ $auth_controller->get('/logout', [$auth, 'logout'])->bind('logout');
 $auth_controller->get('/auth/{auth_type}/authorize', [$auth, 'authorize'])->bind('default_authorize');
 
 // Possible value for ${provider} is only 'azure' now
-$auth_controller->get('/auth/oauth2/{provider}/authorize', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_authorize');
-// For Backward compatibility. (SDK v2.3.3 or below)
-$auth_controller->get('/authorize', [$auth, 'authorizeWithOAuth2'])
-    ->value('provider', 'azure')
-    ->bind('oauth2_authorize_old');
+$auth_controller->get('/auth/oauth2/{provider}/code', [$auth, 'getAuthorizationCode'])->bind('oauth2_code');
+$auth_controller->get('/auth/oauth2/callback', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_callback');
+$auth_controller->get('/auth/oauth2/authorize', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_authorize');
 
-$auth_controller->get('/auth/oauth2/callback', [$auth, 'callbackFromOAuth2'])->bind('oauth2_callback');
 // For Backward compatibility.
-$auth_controller->get('/login-azure', [$auth, 'callbackFromOAuth2'])->bind('oauth2_callback_old');
+$auth_controller->get('/login-azure', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_callback_old');
 
+// For Backward compatibility. (SDK v2.3.3 or below)
+$auth_controller->get('/authorize', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_authorize_old');
 
 $app->mount('/', $auth_controller);
 

--- a/tests/unit/Mock/MockOAuth2Client.php
+++ b/tests/unit/Mock/MockOAuth2Client.php
@@ -18,21 +18,23 @@ class MockOAuth2Client implements OAuth2ClientInterface
 
     public function getAuthorizationUrl(string $scope = null, string $state = null): string
     {
-        return 'authorization url with scope \'' . $scope . '\', and state \'' . $state . '\'';
+        return self::getMockAuthorizationUrl($scope, $state);
     }
 
     public function getTokenWithAuthorizationGrant(string $code): OAuth2Credential
     {
         return new OAuth2Credential(
-            'access_token from code \'' . $code . '\'',
-            'refresh_token from code \'' . $code . '\'');
+            self::getMockAccessTokenWithAuthorizationGrant($code),
+            self::getMockRefreshTokenWithAuthorizationGrant($code)
+        );
     }
 
     public function getTokenWithRefreshGrant(string $refresh_token): OAuth2Credential
     {
         return new OAuth2Credential(
-            'access_token from refresh_token \'' . $refresh_token . '\'',
-            'refresh_token from refresh_token \'' . $refresh_token . '\'');
+            self::getMockAccessTokenWithRefreshGrant($refresh_token),
+            self::getMockRefreshTokenWithRefreshGrant($refresh_token)
+        );
     }
 
     /** @throws InvalidCredentialException */
@@ -44,6 +46,36 @@ class MockOAuth2Client implements OAuth2ClientInterface
     }
 
     public function getResourceOwner(string $access_token)
+    {
+        return self::getMockResourceOwner($access_token);
+    }
+
+    public static function getMockAuthorizationUrl(string $scope = null, string $state = null): string
+    {
+        return 'authorization url with scope \'' . $scope . '\', and state \'' . $state . '\'';
+    }
+
+    public static function getMockAccessTokenWithAuthorizationGrant(string $code)
+    {
+        return 'access_token from code \'' . $code . '\'';
+    }
+
+    public static function getMockRefreshTokenWithAuthorizationGrant(string $code)
+    {
+        return 'refresh_token from code \'' . $code . '\'';
+    }
+
+    public static function getMockAccessTokenWithRefreshGrant(string $refresh_token)
+    {
+        return 'access_token from refresh_token \'' . $refresh_token . '\'';
+    }
+
+    public static function getMockRefreshTokenWithRefreshGrant(string $refresh_token)
+    {
+        return 'refresh_token from refresh_token \'' . $refresh_token . '\'';
+    }
+
+    public static function getMockResourceOwner(string $access_token)
     {
         return 'resource owner from access_token \'' . $access_token . '\'';
     }

--- a/tests/unit/Service/Auth/Authenticator/OAuth2AuthenticatorTest.php
+++ b/tests/unit/Service/Auth/Authenticator/OAuth2AuthenticatorTest.php
@@ -42,7 +42,7 @@ class OAuth2AuthenticatorTest extends TestCase
         $random_state = $this->session->get(OAuth2Authenticator::KEY_STATE);
 
         // an authorization url created by MockOauth2Client
-        $expected = 'authorization url with scope \'some_scope\', and state \'' . $random_state . '\'';
+        $expected = MockOAuth2Client::getMockAuthorizationUrl('some_scope', $random_state);
 
         $this->assertEquals($expected, $actual);
     }
@@ -58,12 +58,12 @@ class OAuth2AuthenticatorTest extends TestCase
 
         $actual_access_token = $this->authenticator->createCredential($request);
         // an access token created by MockOauth2Client
-        $expected_access_token = 'access_token from code \'' . $code . '\'';
+        $expected_access_token = MockOAuth2Client::getMockAccessTokenWithAuthorizationGrant($code);
         $this->assertEquals($expected_access_token, $actual_access_token);
 
         $actual_refresh_token = $this->session->get(OAuth2Authenticator::KEY_REFRESH_TOKEN);
         // a refresh token created by MockOauth2Client
-        $expected_refresh_token = 'refresh_token from code \'' . $code . '\'';
+        $expected_refresh_token = MockOAuth2Client::getMockRefreshTokenWithAuthorizationGrant($code);
         $this->assertEquals($expected_refresh_token, $actual_refresh_token);
     }
 
@@ -91,12 +91,12 @@ class OAuth2AuthenticatorTest extends TestCase
 
         $actual_access_token = $this->authenticator->createCredential($request);
         // an access token created by MockOauth2Client
-        $expected_access_token = 'access_token from refresh_token \'' . $refresh_token . '\'';
+        $expected_access_token = MockOAuth2Client::getMockAccessTokenWithRefreshGrant($refresh_token);
         $this->assertEquals($expected_access_token, $actual_access_token);
 
         $actual_refresh_token = $this->session->get(OAuth2Authenticator::KEY_REFRESH_TOKEN);
         // an refresh token created by MockOauth2Client
-        $expected_refresh_token = 'refresh_token from refresh_token \'' . $refresh_token . '\'';
+        $expected_refresh_token = MockOAuth2Client::getMockRefreshTokenWithRefreshGrant($refresh_token);
         $this->assertEquals($expected_refresh_token, $actual_refresh_token);
     }
 
@@ -133,7 +133,7 @@ class OAuth2AuthenticatorTest extends TestCase
     {
         $access_token = 'some_access_token';
         // an access token created by MockOauth2Client
-        $expected = 'resource owner from access_token \'' . $access_token . '\'';
+        $expected = MockOAuth2Client::getMockResourceOwner($access_token);
         $actual = $this->authenticator->getUserId($access_token);
 
         $this->assertEquals($expected, $actual);
@@ -152,15 +152,15 @@ class OAuth2AuthenticatorTest extends TestCase
 
         $actual_access_token = $this->session->get(OAuth2Authenticator::KEY_ACCESS_TOKEN);
         // an access token created by MockOauth2Client
-        $expected_access_token = 'access_token from code \'' . $code . '\'';
+        $expected_access_token = MockOAuth2Client::getMockAccessTokenWithAuthorizationGrant($code);
         $this->assertEquals($expected_access_token, $actual_access_token);
 
         $actual_refresh_token = $this->session->get(OAuth2Authenticator::KEY_REFRESH_TOKEN);
         // a refresh token created by MockOauth2Client
-        $expected_refresh_token = 'refresh_token from code \'' . $code . '\'';
+        $expected_refresh_token = MockOAuth2Client::getMockrefreshTokenWithAuthorizationGrant($code);
         $this->assertEquals($expected_refresh_token, $actual_refresh_token);
 
-        $expected_user_id = 'resource owner from access_token \'' . $actual_access_token . '\'';
+        $expected_user_id = MockOAuth2Client::getMockResourceOwner($actual_access_token);
         // a resource owner created by MockOauth2Client
         $this->assertEquals($expected_user_id, $actual_user_id);
     }


### PR DESCRIPTION
### 이슈
https://app.asana.com/0/235684600038401/729310572333829/f

### 변경점
- 기존:  
/auth/oauth2/azure/authorize 에서 code grant, refresh grant 방식의 인증 둘 다 수행

- 변경:  
code grant는 새로 /auth/oauth2/azure/code 에서, refresh grant는 그대로 기존 /auth/oauth2/auzre/authorize 에서 수행하도록 변경  

  로그인 검증이나 refresh 토큰 갱신은 기존처럼 ~/azure/authorize에서 처리되는데, 이제 인증에 실패하면 Azure 인증으로 이동시키지 않고 CMS 로그인 페이지로 이동시킵니다.  

  Azure 인증으로 이동하는 부분은 ~/azure/code로 옮겨졌습니다. 이제 로그인 페이지에서 로그인 버튼을 누를 때는 ~/azure/authorize 대신 ~/azure/code로 이동됩니다.