### PR TITLE
Release v2.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.19] - 2018-07-04
+### Fixed
+- Fix to refresh token at `/auth/oauth2/authorize` (#78)
+- Fix test server login id error
+- Configure viewport for mobile UI (#77)
+
+### Changed
+- Make test id available in `introspectToken`
+
 ## [2.1.18] - 2018-06-29
 ### Changed
 - Use 'mailNickName' for azure id instead of 'unique_name'

--- a/src/Service/Auth/OAuth2/Client/AzureClient.php
+++ b/src/Service/Auth/OAuth2/Client/AzureClient.php
@@ -73,6 +73,9 @@ class AzureClient implements OAuth2ClientInterface
         // See https://app.asana.com/0/314089093619591/726274713560091
         $token_object = new AccessToken(['access_token' => $access_token, 'expires' => $token_claims['exp']], $this->azure);
         $user = $this->azure->get('me?api-version=2013-11-08', $token_object);
+        if (empty($user['mailNickname'])) {
+            throw new RuntimeException('Fail to get user info : ' . var_export($user, true));
+        }
 
         return $user['mailNickname'];
     }


### PR DESCRIPTION
## Changes
### Fixed
- Fix to refresh token at `/auth/oauth2/authorize` (#78)
- Fix test server login id error 780dff2
- Configure viewport for mobile UI (#77)

### Changed
- Make test id available in `introspectToken` a65b36a4035213820786ce4eafc797d4f7dbaed8

### Added
- Log details on azure api fail