### PR TITLE
Fix access token expired exception

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -113,7 +113,7 @@ class AuthController
 
         try {
             $user_id = $auth->signIn($request);
-        } catch (NoCredentialException $e) {
+        } catch (NoCredentialException | OAuth2Exception $e) {
             $login_url = $app['url_generator']->generate('login') . '?return_url=' . urlencode($return_url);
             return new RedirectResponse($login_url);
         } catch (InvalidStateException $e) {

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -116,10 +116,12 @@ class AuthController
 
         try {
             $user_id = $auth->signIn($request);
-        } catch (NoCredentialException | OAuth2Exception $e) {
+        } catch (NoCredentialException $e) {
             $login_url = $app['url_generator']->generate('login') . '?return_url=' . urlencode($return_url);
 
             return new RedirectResponse($login_url);
+        } catch (OAuth2Exception $e) {
+            return Response::create($e->getMessage(), Response::HTTP_BAD_REQUEST);
         } catch (InvalidStateException $e) {
             return Response::create($e->getMessage(), Response::HTTP_BAD_REQUEST);
         }

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -22,6 +22,7 @@ class AuthController
     {
         $return_url = $request->get('return_url');
         $authorize_urls = $this->createAuthorizeUrls($app['auth.enabled'], $app['url_generator'], $return_url);
+
         return $app['twig']->render('login.twig', $authorize_urls);
     }
 
@@ -84,6 +85,7 @@ class AuthController
 
         $home_url = $app['url_generator']->generate('home');
         $return_url = $request->get('return_url', $home_url);
+
         return new RedirectResponse($return_url);
     }
 
@@ -99,6 +101,7 @@ class AuthController
         $auth->setReturnUrl($return_url);
 
         $authorization_url = $auth->getAuthorizationUrl($scope);
+
         return new RedirectResponse($authorization_url);
     }
 
@@ -115,6 +118,7 @@ class AuthController
             $user_id = $auth->signIn($request);
         } catch (NoCredentialException | OAuth2Exception $e) {
             $login_url = $app['url_generator']->generate('login') . '?return_url=' . urlencode($return_url);
+
             return new RedirectResponse($login_url);
         } catch (InvalidStateException $e) {
             return Response::create($e->getMessage(), Response::HTTP_BAD_REQUEST);

--- a/src/Service/Auth/AuthMiddleware.php
+++ b/src/Service/Auth/AuthMiddleware.php
@@ -26,6 +26,7 @@ class AuthMiddleware
             } catch (\Exception $e) {
                 $login_url = $app['url_generator']->generate('login');
                 $return_url = $request->getRequestUri();
+
                 return new RedirectResponse($login_url . '?return_url=' . urlencode($return_url));
             }
 

--- a/src/Service/Auth/AuthenticationServiceProvider.php
+++ b/src/Service/Auth/AuthenticationServiceProvider.php
@@ -112,6 +112,7 @@ class AuthenticationServiceProvider implements ServiceProviderInterface, Bootabl
         // Test authenticators
         $app['auth.authenticator.test'] = function (Container $app) {
             $test_option = $app['auth.options']['test'] ?? [];
+
             return new TestAuthenticator($app['auth.session'], $test_option['test_user_id']);
         };
     }

--- a/src/Service/Auth/Authenticator/OAuth2Authenticator.php
+++ b/src/Service/Auth/Authenticator/OAuth2Authenticator.php
@@ -36,6 +36,7 @@ class OAuth2Authenticator extends BaseAuthenticator
         $this->session->set(self::KEY_STATE, $state);
 
         $client = $this->getOAuth2Client();
+
         return $client->getAuthorizationUrl($scope, $state);
     }
 
@@ -48,12 +49,8 @@ class OAuth2Authenticator extends BaseAuthenticator
         $code = $request->get('code');
         if (!empty($code)) {
             $state = $request->get('state');
-            return $this->createCredentialWithAuthorizationCode($code, $state ?? "");
-        }
 
-        $access_token = $this->session->get(self::KEY_ACCESS_TOKEN);
-        if (!empty($access_token)) {
-            return $access_token;
+            return $this->createCredentialWithAuthorizationCode($code, $state ?? "");
         }
 
         $refresh_token = $this->session->get(self::KEY_REFRESH_TOKEN);

--- a/src/Service/Auth/Authenticator/OAuth2Authenticator.php
+++ b/src/Service/Auth/Authenticator/OAuth2Authenticator.php
@@ -48,9 +48,9 @@ class OAuth2Authenticator extends BaseAuthenticator
     {
         $code = $request->get('code');
         if (!empty($code)) {
-            $state = $request->get('state');
+            $state = $request->get('state', '');
 
-            return $this->createCredentialWithAuthorizationCode($code, $state ?? "");
+            return $this->createCredentialWithAuthorizationCode($code, $state);
         }
 
         $refresh_token = $this->session->get(self::KEY_REFRESH_TOKEN);

--- a/src/Service/Auth/Session/CookieSessionStorage.php
+++ b/src/Service/Auth/Session/CookieSessionStorage.php
@@ -28,6 +28,7 @@ class CookieSessionStorage implements SessionStorageInterface
     public function get(string $key_name): ?string
     {
         $values = array_merge($this->origin, $this->modified);
+
         return $values[$key_name] ?? null;
     }
 

--- a/src/Service/ThriftServiceProvider.php
+++ b/src/Service/ThriftServiceProvider.php
@@ -36,6 +36,7 @@ class ThriftServiceProvider implements ServiceProviderInterface, BootableProvide
         $app['thrift.processor'] = function () {
             return function (Request $request, Application $app) {
                 $output = $app['thrift.server']->process($request->getContent());
+
                 return new Response($output, Response::HTTP_OK, [
                     'Content-Type' => 'application/x-thrift'
                 ]);

--- a/tests/unit/Controller/AuthControllerTest.php
+++ b/tests/unit/Controller/AuthControllerTest.php
@@ -44,6 +44,7 @@ class AuthControllerTest extends TestCase
         $app->extend('twig', function (\Twig_Environment $twig) {
             $twig->addGlobal('STATIC_URL', '/static');
             $twig->addGlobal('BOWER_PATH', '/static/bower_components');
+
             return $twig;
         });
 


### PR DESCRIPTION
Fixed `Expired token` exception during `/authorize` call. 
It happens when token cookie exists but has expired.

## Changed
- `createCredential` now refreshes tokens instead of just returning access token.
- Added missing exception handlings.