### PR TITLE
Fix the bug that prevents authorizing-by-tag on dev environment

### DIFF
--- a/src/Service/AdminAuthService.php
+++ b/src/Service/AdminAuthService.php
@@ -95,11 +95,11 @@ class AdminAuthService extends Container
      */
     public function authorizeByTag(string $token, array $tags)
     {
-        $user_id = self::introspectToken($token);
-
-        if (!empty($_ENV['TEST_AUTH_DISABLE'])) {
+        if (!empty($token) && !empty($_ENV['TEST_AUTH_DISABLE'])) {
             return;
         }
+
+        $user_id = self::introspectToken($token);
 
         if (!self::checkAuthByTag($user_id, $tags)) {
             throw new UnauthorizedException([


### PR DESCRIPTION
### 배경
테스트환경에서 `Signed in with Test`로 인증받았어도 authorizeByTag가 Azure인증을 체크해서 Malformed Token 예외를 발생시키는 버그가 있었습니다.

### 코드 설명
authorizeByTag가 테스트 인증인지 먼저 체크해서 introspectToken을 건너뛰어야 하는데, 체크를 introspectToken 호출 후 수행하도록 되어있었습니다.

여태까지 발견안된 것이 신기한 버그입니다(...)