### PR TITLE
Add token API

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,3 +1,6 @@
+XDEBUG_ENABLE=1
+XDEBUG_HOST=host.docker.internal
+
 DEBUG=1
 SENTRY_KEY=
 

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "type": "project",
   "license": "MIT",
   "require": {
+    "ext-json": "*",
     "illuminate/database": "^5.2",
     "jguyomard/silex-capsule-eloquent": "^2.0",
     "guzzlehttp/guzzle": "^6.3",

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -12,6 +12,7 @@ use Ridibooks\Cms\Service\Auth\OAuth2\Client\AzureClient;
 use Ridibooks\Cms\Service\Auth\OAuth2\Exception\InvalidStateException;
 use Ridibooks\Cms\Service\Auth\OAuth2\Exception\OAuth2Exception;
 use Silex\Application;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -104,6 +105,24 @@ class AuthController
         $authorization_url = $auth->getAuthorizationUrl($scope);
 
         return new RedirectResponse($authorization_url);
+    }
+
+    public function getToken(Request $request, Application $app)
+    {
+        /** @var OAuth2Authenticator $auth */
+        $auth = $app['auth.authenticator.oauth2'];
+
+        try {
+            $auth->createCredential($request);
+        } catch (NoCredentialException | InvalidStateException $e) {
+            return new JsonResponse([
+                'result' => 'fail'
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return new JsonResponse([
+            'result' => 'success'
+        ], Response::HTTP_OK);
     }
 
     public function authorizeWithOAuth2(Request $request, Application $app)

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -116,12 +116,12 @@ class AuthController
             $auth->createCredential($request);
         } catch (NoCredentialException | InvalidStateException $e) {
             return new JsonResponse([
-                'result' => 'fail'
+                'message' => $e->getMessage(),
             ], Response::HTTP_UNAUTHORIZED);
         }
 
         return new JsonResponse([
-            'result' => 'success'
+            'message' => 'success'
         ], Response::HTTP_OK);
     }
 

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -15,6 +15,7 @@ $auth_controller->get('/logout', [$auth, 'logout'])->bind('logout');
 
 // Possible value for ${provider} is only 'azure' now
 $auth_controller->get('/auth/oauth2/{provider}/code', [$auth, 'getAuthorizationCode'])->bind('oauth2_code');
+$auth_controller->get('/auth/oauth2/{provider}/token', [$auth, 'getToken'])->bind('oauth2_token');
 $auth_controller->get('/auth/oauth2/callback', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_callback');
 $auth_controller->get('/auth/oauth2/authorize', [$auth, 'authorizeWithOAuth2'])->bind('oauth2_authorize');
 

--- a/tests/unit/Controller/AuthControllerTest.php
+++ b/tests/unit/Controller/AuthControllerTest.php
@@ -275,7 +275,7 @@ class AuthControllerTest extends TestCase
         $response = $this->app->handle($request);
         $this->assertEquals($response->getStatusCode(), Response::HTTP_UNAUTHORIZED);
         $this->assertEquals($response->getContent(), json_encode([
-            'result' => 'fail',
+            'message' => 'no token exists',
         ]));
 
         $session = $this->app['auth.session'];
@@ -296,7 +296,7 @@ class AuthControllerTest extends TestCase
         $response = $this->app->handle($request);
         $this->assertEquals($response->getStatusCode(), Response::HTTP_OK);
         $this->assertEquals($response->getContent(), json_encode([
-            'result' => 'success',
+            'message' => 'success',
         ]));
 
         $session = $this->app['auth.session'];

--- a/tests/unit/Controller/AuthControllerTest.php
+++ b/tests/unit/Controller/AuthControllerTest.php
@@ -75,6 +75,8 @@ class AuthControllerTest extends TestCase
 
         $app->get('/oauth2/{provider}/code', [$this->controller, 'getAuthorizationCode'])->bind('oauth2_code');
 
+        $app->get('/oauth2/{provider}/token', [$this->controller, 'getToken'])->bind('oauth2_token');
+
         $app->get('/oauth2/authorize', [$this->controller, 'authorizeWithOAuth2'])
             ->bind('oauth2_authorize');
 
@@ -264,5 +266,43 @@ class AuthControllerTest extends TestCase
 
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertEquals('state is not matched', $response->getContent());
+    }
+
+    public function testGetTokenIfNoTokenExists()
+    {
+        $request = Request::create('/oauth2/' . AzureClient::PROVIDER_NAME . '/token', 'GET');
+
+        $response = $this->app->handle($request);
+        $this->assertEquals($response->getStatusCode(), Response::HTTP_UNAUTHORIZED);
+        $this->assertEquals($response->getContent(), json_encode([
+            'result' => 'fail',
+        ]));
+
+        $session = $this->app['auth.session'];
+        $this->assertNull($session->get(OAuth2Authenticator::KEY_ACCESS_TOKEN));
+        $this->assertNull($session->get(OAuth2Authenticator::KEY_REFRESH_TOKEN));
+    }
+
+    public function testGetTokenIfRefreshTokenExists()
+    {
+        $refresh_token = 'some-refresh-token';
+
+        $request = Request::create('/oauth2/' . AzureClient::PROVIDER_NAME . '/token', 'GET', [], [
+            'auth_type' => OAuth2Authenticator::AUTH_TYPE,
+            'oauth2_provider' => AzureClient::PROVIDER_NAME,
+            'cms-refresh' => $refresh_token,
+        ]);
+
+        $response = $this->app->handle($request);
+        $this->assertEquals($response->getStatusCode(), Response::HTTP_OK);
+        $this->assertEquals($response->getContent(), json_encode([
+            'result' => 'success',
+        ]));
+
+        $session = $this->app['auth.session'];
+        $this->assertEquals($session->get(BaseAuthenticator::KEY_AUTH_TYPE), OAuth2Authenticator::AUTH_TYPE);
+        $this->assertEquals($session->get(OAuth2Authenticator::KEY_PROVIDER), AzureClient::PROVIDER_NAME);
+        $this->assertEquals($session->get(OAuth2Authenticator::KEY_ACCESS_TOKEN), MockOAuth2Client::getMockAccessTokenWithRefreshGrant($refresh_token));
+        $this->assertEquals($session->get(OAuth2Authenticator::KEY_REFRESH_TOKEN), MockOAuth2Client::getMockRefreshTokenWithRefreshGrant($refresh_token));
     }
 }


### PR DESCRIPTION
리디셀렉트 어드민 프론트엔드를 분리하고 있는데, 백엔드를 거치지 않고 직접 CMS와 통신해서 인증처리를 하려고 합니다. 토큰을 갱신해야 할 경우에 사용할 API가 없어서 추가했습니다.

기존에 비슷한 역할로는 `/auth/oauth2/authorize`가 있습니다. 하지만 이건 cms-sdk에서 인증 실패 판별 후 유저로 하려금 인증을 받아오라고 보내는 리다이렉션 전용 url 입니다.  지금 필요한 기능은 1) 토큰을 갱신하고, 2) 갱신이 불가능한 경우 (로그인 페이지 302 응답을 보내는 것이 아니라) 401 응답을 내어주는 토큰 갱신 전용 API입니다.

