### PR TITLE
Apply a security header with CMS Middleware

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -56,8 +56,8 @@ $app->after(function (Request $request, Response $response) {
     $response->headers->set('X-Frame-Options', 'DENY');
     $response->headers->set('X-Content-Type-Options', 'nosniff');
     $response->headers->set('X-XSS-Protection', '1; mode=block');
-    $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; report-uri /cms_csp_report;");
-});
+    $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; report-uri https://gyx3tts4g8.execute-api.ap-northeast-2.amazonaws.com/default/perf-csp-reports-lambda;");
+});$
 
 // TODO: error handler
 //$app->error(function () {

--- a/src/app.php
+++ b/src/app.php
@@ -52,6 +52,13 @@ $app->register(new Service\Auth\AuthenticationServiceProvider(), [
     },
 ]);
 
+$app->after(function (Request $request, Response $response) {
+    $response->headers->set('X-Frame-Options', 'DENY');
+    $response->headers->set('X-Content-Type-Options', 'nosniff');
+    $response->headers->set('X-XSS-Protection', '1; mode=block');
+    $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; report-uri /cms_csp_report;");
+});
+
 // TODO: error handler
 //$app->error(function () {
 //

--- a/src/app.php
+++ b/src/app.php
@@ -10,6 +10,9 @@ use Ridibooks\Cms\Service;
 use Ridibooks\Cms\Service\Auth\OAuth2\Client\AzureClient;
 use Ridibooks\Cms\Thrift;
 use Silex\Provider\MonologServiceProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
 
 $app = new CmsApplication($config);
 
@@ -57,7 +60,7 @@ $app->after(function (Request $request, Response $response) {
     $response->headers->set('X-Content-Type-Options', 'nosniff');
     $response->headers->set('X-XSS-Protection', '1; mode=block');
     $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; report-uri https://gyx3tts4g8.execute-api.ap-northeast-2.amazonaws.com/default/perf-csp-reports-lambda;");
-});$
+});
 
 // TODO: error handler
 //$app->error(function () {

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -41,7 +41,5 @@ $common_controller->get('/welcome', [$common, 'getWelcomePage'])->bind('home');
 $common_controller->get('/me', [$common, 'getMyInfo'])->bind('me');
 $common_controller->post('/me', [$common, 'updateMyInfo']);
 $common_controller->get('/comm/user_list.ajax', [$common, 'userList']); // TODO: Remove this
-// TODO: Be append a 'Content Security Policy' reporting path
-// $common_controller->get('/cms_csp_report', [$common, 'cspReport']); 
 
 $app->mount('/', $common_controller);

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -41,5 +41,7 @@ $common_controller->get('/welcome', [$common, 'getWelcomePage'])->bind('home');
 $common_controller->get('/me', [$common, 'getMyInfo'])->bind('me');
 $common_controller->post('/me', [$common, 'updateMyInfo']);
 $common_controller->get('/comm/user_list.ajax', [$common, 'userList']); // TODO: Remove this
+// TODO: Be append a 'Content Security Policy' reporting path
+// $common_controller->get('/cms_csp_report', [$common, 'cspReport']); 
 
 $app->mount('/', $common_controller);


### PR DESCRIPTION
# 개요 
https://app.asana.com/0/939760765810445/1127194147283316/f

- 해당 제보(open redirect, reflected xss) 의 장기적 대응 PR입니다. 
- 단기적 대응은 #94 에서 진행 중입니다. 

## 변경사항
 cms after 미들웨어가 추가되었습니다.
- response 헤더에 다음과 같은 내용이 모든 response header 에 추가됩니다. 

> X-Frame-Options: DENY
> X-Content-Type-Options: nosniff
> X-XSS-Protection: 1; mode=block
> Content-Security-Policy-Report-Only: default-src 'self'; report-uri https://gyx3tts4g8.execute-api.ap-northeast-2.amazonaws.com/default/perf-csp-reports-lambda;

- csp reporting을 위해 다음과 같은 uri가 추가되었습니다.  
  - `https://gyx3tts4g8.execute-api.ap-northeast-2.amazonaws.com/default/perf-csp-reports-lambda`
  - 해당 url은 퍼포먼스팀 개발환경에서 동작하는 lamba function 이며, api gateway로 endpoint를 생성하였습니다.
  - [api gateway aws 프리티어 사용량](https://aws.amazon.com/ko/api-gateway/pricing/)을 초과하지 않을것으로 예상됩니다.


## 비고
`Content-Security-Policy-Report-Only`으로 리포팅된 결과를 바탕으로 `Content-Security-Policy`를 적용할 예정입니다. [참고링크](https://developers.google.com/web/fundamentals/security/csp/?hl=ko#%EB%B3%B4%EA%B3%A0%EC%84%9C_%EC%A0%84%EC%9A%A9)


