### PR TITLE
getFilteredReturnUrl  내 backslash 필터링 추가 

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -33,7 +33,7 @@ class AuthController
         return $is_allowed;
     }
 
-    public static function escapeUrl($url)
+    private function escapeUrl($url)
     {
         // customized escape charset
         $escape_charset = get_html_translation_table(HTML_ENTITIES, ENT_QUOTES);
@@ -54,7 +54,7 @@ class AuthController
         }
 
         try {
-            $uri = new Uri(self::escapeUrl($return_url));
+            $uri = new Uri($this->escapeUrl($return_url));
 
             // Uri()->with{*} 메서드에서 Uri::validateState() 를 호출하는데, host==='' 일 경우 host 를 'localhost' 로 캐스팅하므로,
             // Scheme 검사보다 Host 검사가 먼저 이루어 져야 함.

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -33,9 +33,19 @@ class AuthController
         return $is_allowed;
     }
 
+    public static function escapeUrl($url)
+    {
+        // customized escape charset
+        $escape_charset = get_html_translation_table(HTML_ENTITIES, ENT_QUOTES);
+        $escape_charset['\\'] = '';
+        unset($escape_charset['&']);
+
+        return str_replace(array_keys($escape_charset), array_values($escape_charset), $url);
+    }
+
     /**
      * Forked by store/store getFilteredReturnUrl
-     * source: https://gitlab.com/ridicorp/store/store/blob/46e3e72b1fe6bd11ee45c6f20de4556cbbec5cd5/src/Ridibooks/Store/Library/UrlGenerator.php#L251
+     * source: https://gitlab.com/ridicorp/store/store/blob/7406f65d89bd5724e92156243048955f3a2672e7/src/Ridibooks/Store/Library/UrlGenerator.php#L251
      */
     public function getFilteredReturnUrl(string $return_url)
     {
@@ -44,7 +54,7 @@ class AuthController
         }
 
         try {
-            $uri = new Uri(htmlentities($return_url, ENT_QUOTES));
+            $uri = new Uri(self::escapeUrl($return_url));
 
             // Uri()->with{*} 메서드에서 Uri::validateState() 를 호출하는데, host==='' 일 경우 host 를 'localhost' 로 캐스팅하므로,
             // Scheme 검사보다 Host 검사가 먼저 이루어 져야 함.


### PR DESCRIPTION
## 개요 
https://app.asana.com/0/1127742852096038/1130217216318990/f
return_url에서 backslash 필터링이 되지 않아 open redirect 취약점 발생합니다.

## 변경사항
 `\` 를 escape 하도록  필터링을 추가하였습니다. 
`&`를 escape하지 않도록 예외를 추가하였습니다.