### PR TITLE
csp 리포트 제거 및 ci  설정 업데이트

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-sudo: false
 dist: trusty
 language: generic
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - echo "Wait for applying DB schema change.."; sleep 3s
   - make test
 
-after_scipt:
+after_script:
   - make down
 
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add \
     php7-pdo \
     php7-pdo_mysql \
 && rm -rf /var/cache/apk/* \
-&& npm install -g bower
+&& npm install --unsafe-perm=true -g bower
 
 WORKDIR /build
 

--- a/src/app.php
+++ b/src/app.php
@@ -59,7 +59,6 @@ $app->after(function (Request $request, Response $response) {
     $response->headers->set('X-Frame-Options', 'DENY');
     $response->headers->set('X-Content-Type-Options', 'nosniff');
     $response->headers->set('X-XSS-Protection', '1; mode=block');
-    $response->headers->set('Content-Security-Policy-Report-Only', "default-src 'self'; report-uri https://sentry.io/api/149535/security/?sentry_key=b17d9550ab1547e1862a091b3d196ebc;");
 });
 
 // TODO: error handler


### PR DESCRIPTION
# 개요
https://app.asana.com/0/1163015767457465/1163249052485321/f
# 변경사항 
- sentry csp report 삭제
- deprecated된 sudo 태그를 삭제하였습니다.
- 오타 수정 | after_scrpt -> after_script 
- npm 설치 시, --unsafe-perm=true 파라미터 추가 
  - 패키지 설치 시, uid, gid 를 전환하지 않습니다. 
  -  https://docs.npmjs.com/misc/config#unsafe-perm
  -  https://geedew.com/What-does-unsafe-perm-in-npm-actually-do/